### PR TITLE
Removed hard requirement on javax.persistence (still included as test…

### DIFF
--- a/coherence-spring-data/pom.xml
+++ b/coherence-spring-data/pom.xml
@@ -73,12 +73,6 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>javax</groupId>
-			<artifactId>javaee-api</artifactId>
-			<version>${javaee-api.version}</version>
-			<scope>provided</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -137,6 +131,12 @@
 			<groupId>javax.annotation</groupId>
 			<artifactId>javax.annotation-api</artifactId>
 			<version>${javax.annotation-api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax</groupId>
+			<artifactId>javaee-api</artifactId>
+			<version>${javaee-api.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/coherence-spring-data/src/main/java/com/oracle/coherence/spring/data/core/mapping/CoherencePersistentProperty.java
+++ b/coherence-spring-data/src/main/java/com/oracle/coherence/spring/data/core/mapping/CoherencePersistentProperty.java
@@ -6,14 +6,16 @@
  */
 package com.oracle.coherence.spring.data.core.mapping;
 
-import javax.persistence.Id;
+import com.tangosol.util.Base;
 
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.Association;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.util.ClassUtils;
 
 /**
  * Coherence implementation of {@link PersistentProperty}.
@@ -23,6 +25,18 @@ import org.springframework.data.mapping.model.SimpleTypeHolder;
  */
 public class CoherencePersistentProperty
 		extends AnnotationBasedPersistentProperty<CoherencePersistentProperty> {
+
+	/**
+	 * Eventually consistent flag indicating the check for javax.persistence has been
+	 * made.
+	 */
+	private boolean javaxPersistenceChecked;
+
+	/**
+	 * The {@code javax.persistence.Id} annotation if found.  This is a fallback
+	 * to {@link Id}.
+	 */
+	private Class javaxPersistenceId;
 
 	public CoherencePersistentProperty(Property property,
 			PersistentEntity<?, CoherencePersistentProperty> owner, SimpleTypeHolder simpleTypeHolder) {
@@ -37,6 +51,23 @@ public class CoherencePersistentProperty
 
 	@Override
 	public boolean isIdProperty() {
-		return findAnnotation(Id.class) != null;
+		if (findAnnotation(Id.class) != null) {
+			return true;
+		}
+		else {
+			if (!this.javaxPersistenceChecked) {
+				this.javaxPersistenceChecked = true;
+				try {
+					this.javaxPersistenceId =
+							ClassUtils.forName("javax.persistence.Id", Base.getContextClassLoader());
+				}
+				catch (ClassNotFoundException ignored) {
+				}
+			}
+			if (this.javaxPersistenceId != null) {
+				return findAnnotation(this.javaxPersistenceId) != null;
+			}
+			return false;
+		}
 	}
 }

--- a/coherence-spring-data/src/main/java/com/oracle/coherence/spring/data/repository/query/CoherenceRepositoryQuery.java
+++ b/coherence-spring-data/src/main/java/com/oracle/coherence/spring/data/repository/query/CoherenceRepositoryQuery.java
@@ -18,8 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nullable;
-
 import com.oracle.coherence.spring.data.support.Utils;
 import com.tangosol.net.NamedMap;
 import com.tangosol.util.Aggregators;
@@ -49,6 +47,7 @@ import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.data.repository.query.ReturnedType;
 import org.springframework.data.repository.query.parser.PartTree;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.ReflectionUtils;
 

--- a/coherence-spring-data/src/main/java/com/oracle/coherence/spring/data/support/CoherenceRepositoryConfigurationExtension.java
+++ b/coherence-spring-data/src/main/java/com/oracle/coherence/spring/data/support/CoherenceRepositoryConfigurationExtension.java
@@ -6,11 +6,8 @@
  */
 package com.oracle.coherence.spring.data.support;
 
-import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
-
-import javax.persistence.Entity;
 
 import com.oracle.coherence.spring.configuration.CoherenceSpringConfiguration;
 import com.oracle.coherence.spring.data.repository.CoherenceRepository;
@@ -40,11 +37,6 @@ public class CoherenceRepositoryConfigurationExtension extends RepositoryConfigu
 	@Override
 	protected String getModulePrefix() {
 		return "coherence";
-	}
-
-	@Override
-	protected Collection<Class<? extends Annotation>> getIdentifyingAnnotations() {
-		return Collections.singleton(Entity.class);
 	}
 
 	@Override

--- a/coherence-spring-data/src/test/java/com/oracle/coherence/spring/data/model/Book.java
+++ b/coherence-spring-data/src/test/java/com/oracle/coherence/spring/data/model/Book.java
@@ -14,15 +14,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-
 import com.tangosol.util.UUID;
+
+import org.springframework.data.annotation.Id;
 
 /**
  * An entity for representing a {@code book}.
  */
-@Entity
 public class Book implements Cloneable, Serializable {
 	/**
 	 * The unique id of this book.

--- a/coherence-spring-docs/src/main/asciidoc/spring-data.adoc
+++ b/coherence-spring-docs/src/main/asciidoc/spring-data.adoc
@@ -112,23 +112,21 @@ public interface PersonRepository extends CoherenceRepository<String, Person> {
 == Mapping Entities
 
 As Coherence is, at its core, a key-value store, mapping Entities for use with a Coherence
-Repository is relatively simple.  It requires using the `javax.persistence.Entity` annotation
-to define the domain type that will be persisted, and the `javax.persistence.Id` annotation to denote the entity's id.
+Repository is relatively simple as only the id needs to be annotated.  It is possible to
+use either `org.springframework.data.annotation.Id` or `javax.persistence.Id` to denote the
+entity's id.
 
 For example:
 
 [source,java]
 ----
-@javax.persistence.Entity
 public class Person implements Serializable {
-	@javax.persistence.Id
+	@org.springframework.data.annotation.Id
 	protected String id;
 
 	// ---- person functionality ----
 }
 ----
-
-Any other `javax.persistence` annotations will not be considered by the runtime.
 
 == Using the Repository
 


### PR DESCRIPTION
Removed hard requirement on javax.persistence (still included as test dependency).
No longer need to use @Entity to 'map' an entity.
Support both org.springframework.data.annotation.Id and javax.persistence.Id annotations.