### PR TITLE
Add spring-boot-autoconfigure-processor dependency

### DIFF
--- a/coherence-spring-boot-starter/pom.xml
+++ b/coherence-spring-boot-starter/pom.xml
@@ -105,6 +105,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<version>${spring-boot.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<version>${spring-boot.version}</version>
 			<optional>true</optional>


### PR DESCRIPTION
Generate metadata file `META-INF/spring-autoconfigure-metadata.properties`
which will improve the startup.

See https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#features.developing-auto-configuration.custom-starter.autoconfigure-module
