### PR TITLE
Add additional-spring-configuration-metadata.json

### DIFF
--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/session/CoherenceSessionProperties.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/session/CoherenceSessionProperties.java
@@ -12,7 +12,7 @@ import org.springframework.session.SaveMode;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * Coherence congiguration properties for Spring Session.
+ * Coherence configuration properties for Spring Session.
  *
  * @author Gunnar Hillert
  * @since 3.0
@@ -20,11 +20,6 @@ import org.springframework.validation.annotation.Validated;
 @ConfigurationProperties(prefix = "coherence.spring.session")
 @Validated
 public class CoherenceSessionProperties {
-
-	/**
-	 * Is Spring Session support enabled?
-	 */
-	private boolean enabled = false;
 
 	/**
 	 * Name of the map used to store sessions.
@@ -65,14 +60,6 @@ public class CoherenceSessionProperties {
 
 	public void setSaveMode(SaveMode saveMode) {
 		this.saveMode = saveMode;
-	}
-
-	public boolean isEnabled() {
-		return this.enabled;
-	}
-
-	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 	}
 
 }

--- a/coherence-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/coherence-spring-boot-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "defaultValue": true,
+      "name": "coherence.spring.session.enabled",
+      "description": "Enables Coherence integration.",
+      "type": "java.lang.Boolean"
+    }
+  ]
+}


### PR DESCRIPTION
Configuration property `enabled` at `CoherenceSessionProperties`
is moved to `additional-spring-configuration-metadata.json`.
