### PR TITLE
Using Spring JPA repository beans as Coherence cache stores

### DIFF
--- a/coherence-spring-core/pom.xml
+++ b/coherence-spring-core/pom.xml
@@ -67,6 +67,11 @@
 			<artifactId>spring-messaging</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-jpa</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax</groupId>
 			<artifactId>javaee-api</artifactId>
 			<version>${javaee-api.version}</version>

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/CoherenceContext.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/CoherenceContext.java
@@ -6,6 +6,8 @@
  */
 package com.oracle.coherence.spring;
 
+import javax.inject.Inject;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
@@ -29,9 +31,9 @@ public class CoherenceContext {
 	 * Create a {@link CoherenceContext}.
 	 * @param ctx the {@link ApplicationContext}
 	 */
-
+	@Inject
 	public CoherenceContext(ApplicationContext ctx) {
-		CoherenceContext.ctx = ctx;
+		setApplicationContext(ctx);
 	}
 
 	/**
@@ -40,5 +42,15 @@ public class CoherenceContext {
 	 */
 	public static ApplicationContext getApplicationContext() {
 		return ctx;
+	}
+
+	/**
+	 * Set the global {@link ApplicationContext}.
+	 * @param ctx  the {@link ApplicationContext} to be used by Coherence classes
+	 */
+	public static void setApplicationContext(ApplicationContext ctx) {
+		if (ctx != null) {
+			CoherenceContext.ctx = ctx;
+		}
 	}
 }

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/CoherenceServer.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/CoherenceServer.java
@@ -107,6 +107,9 @@ public class CoherenceServer implements InitializingBean, SmartLifecycle, Applic
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = applicationContext;
+		// We need to ensure that the context is injected into the CoherenceContext to work around
+		// any race where Spring may not yet have done this for us
+		CoherenceContext.setApplicationContext(applicationContext);
 	}
 
 	@Override

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cachestore/JpaRepositoryCacheLoader.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cachestore/JpaRepositoryCacheLoader.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
 package com.oracle.coherence.spring.cachestore;
 
 import java.util.Collection;

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cachestore/JpaRepositoryCacheLoader.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cachestore/JpaRepositoryCacheLoader.java
@@ -1,0 +1,55 @@
+package com.oracle.coherence.spring.cachestore;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+
+import com.oracle.coherence.spring.CoherenceContext;
+import com.tangosol.net.cache.CacheLoader;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * A Coherence {@link CacheLoader} that is also a {@link JpaRepository} allowing the
+ * loader methods to use the repository to load data.
+ *
+ * @param <T> the domain type the repository manages and the type of values in the cache
+ * @param <ID> the type of the id of the entity the repository manages and the type of the
+ * cache key
+ * @author Jonathan Knight 2021.08.17
+ */
+@NoRepositoryBean
+public interface JpaRepositoryCacheLoader<T, ID> extends JpaRepository<T, ID>, CacheLoader<ID, T> {
+
+	/**
+	 * Returns the cache key for the given entity value.
+	 * @param value the entity value to obtain the cache key from
+	 * @return the cache key for the given entity value
+	 */
+	@SuppressWarnings("unchecked")
+	default ID getId(T value) {
+		EntityManager em = CoherenceContext.getApplicationContext().getBean(EntityManager.class);
+		return (ID) em.getEntityManagerFactory().getPersistenceUnitUtil().getIdentifier(value);
+	}
+
+	@Transactional
+	@Override
+	default T load(ID key) {
+		return findById(key).orElse(null);
+	}
+
+	@Transactional
+	@Override
+	@SuppressWarnings("unchecked")
+	default Map<ID, T> loadAll(Collection<? extends ID> colKeys) {
+		Map<ID, T> map = new HashMap<>();
+		Collection<ID> keys = (Collection<ID>) colKeys;
+		findAllById(keys).forEach((v) -> map.put(getId(v), v));
+		return map;
+	}
+
+}

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cachestore/JpaRepositoryCacheStore.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cachestore/JpaRepositoryCacheStore.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
 package com.oracle.coherence.spring.cachestore;
 
 import java.util.Collection;

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cachestore/JpaRepositoryCacheStore.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cachestore/JpaRepositoryCacheStore.java
@@ -1,0 +1,77 @@
+package com.oracle.coherence.spring.cachestore;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.tangosol.net.cache.CacheStore;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * A generic Spring JPA {@link CacheStore} that extends a Spring {@link JpaRepository} for
+ * the database operations.
+ *
+ * @param <T> the domain type the repository manages and the type of values in the cache
+ * @param <ID> the type of the id of the entity the repository manages and the type of the
+ * cache key
+ * @author Jonathan Knight 2021.08.17
+ */
+@NoRepositoryBean
+public interface JpaRepositoryCacheStore<T, ID> extends JpaRepositoryCacheLoader<T, ID>, CacheStore<ID, T> {
+
+	@Transactional
+	@Override
+	default void erase(ID key) {
+		deleteById(key);
+		flush();
+	}
+
+	@Transactional
+	@Override
+	default void eraseAll(Collection<? extends ID> colKeys) {
+		boolean fRemove = true;
+		for (Iterator<? extends ID> iter = colKeys.iterator(); iter.hasNext();) {
+			this.deleteById(iter.next());
+			erase(iter.next());
+			if (fRemove) {
+				try {
+					iter.remove();
+				}
+				catch (UnsupportedOperationException ex) {
+					fRemove = false;
+				}
+			}
+		}
+		flush();
+	}
+
+	@Transactional
+	@Override
+	default void store(ID key, T value) {
+		saveAndFlush(value);
+	}
+
+	@Transactional
+	@Override
+	default void storeAll(Map<? extends ID, ? extends T> entries) {
+		boolean fRemove = true;
+		for (Iterator<? extends Map.Entry<? extends ID, ? extends T>> iter = entries.entrySet().iterator(); iter
+				.hasNext();) {
+			Map.Entry<? extends ID, ? extends T> entry = iter.next();
+			save(entry.getValue());
+			if (fRemove) {
+				try {
+					iter.remove();
+				}
+				catch (UnsupportedOperationException ex) {
+					fRemove = false;
+				}
+			}
+			flush();
+		}
+	}
+
+}

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/annotation/CoherenceAsyncCache.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/annotation/CoherenceAsyncCache.java
@@ -17,6 +17,7 @@ import com.oracle.coherence.spring.annotation.SessionName;
 import com.oracle.coherence.spring.configuration.NamedCacheConfiguration;
 import com.tangosol.net.Coherence;
 
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.AliasFor;
 
 /**
@@ -32,6 +33,7 @@ import org.springframework.core.annotation.AliasFor;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @CoherenceAsyncMap
+@Lazy
 public @interface CoherenceAsyncCache {
 
 	@AliasFor(annotation = Name.class)

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/annotation/CoherenceAsyncMap.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/annotation/CoherenceAsyncMap.java
@@ -18,6 +18,7 @@ import com.oracle.coherence.spring.configuration.NamedCacheConfiguration;
 import com.tangosol.net.Coherence;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.AliasFor;
 
 /**
@@ -34,6 +35,7 @@ import org.springframework.core.annotation.AliasFor;
 @Documented
 @CoherenceCache
 @Value("#{" + NamedCacheConfiguration.COHERENCE_ASYNC_CACHE_BEAN_NAME + "}")
+@Lazy
 public @interface CoherenceAsyncMap {
 
 	@AliasFor(annotation = Name.class)

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/annotation/CoherenceCache.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/annotation/CoherenceCache.java
@@ -16,6 +16,7 @@ import com.oracle.coherence.spring.annotation.Name;
 import com.oracle.coherence.spring.annotation.SessionName;
 import com.tangosol.net.Coherence;
 
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.AliasFor;
 
 /**
@@ -30,6 +31,7 @@ import org.springframework.core.annotation.AliasFor;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @CoherenceMap
+@Lazy
 public @interface CoherenceCache {
 
 	@AliasFor(annotation = Name.class)

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/annotation/CoherenceMap.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/annotation/CoherenceMap.java
@@ -18,6 +18,7 @@ import com.oracle.coherence.spring.configuration.NamedCacheConfiguration;
 import com.tangosol.net.Coherence;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.AliasFor;
 
 /**
@@ -34,6 +35,7 @@ import org.springframework.core.annotation.AliasFor;
 @Value("#{" + NamedCacheConfiguration.COHERENCE_CACHE_BEAN_NAME + "}")
 @Name
 @SessionName
+@Lazy
 public @interface CoherenceMap {
 
 	@AliasFor(annotation = Name.class)

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/namespace/BeanBuilder.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/namespace/BeanBuilder.java
@@ -6,9 +6,11 @@
  */
 package com.oracle.coherence.spring.namespace;
 
+import java.text.ParseException;
 import java.util.Objects;
 
 import com.tangosol.coherence.config.ParameterList;
+import com.tangosol.coherence.config.ParameterMacroExpressionParser;
 import com.tangosol.coherence.config.builder.ParameterizedBuilder;
 import com.tangosol.config.ConfigurationException;
 import com.tangosol.config.expression.Expression;
@@ -45,7 +47,14 @@ public class BeanBuilder implements ParameterizedBuilder<Object>, ParameterizedB
 	 */
 	BeanBuilder(ApplicationContext context, String beanNameExpression) {
 		this.context = Objects.requireNonNull(context);
-		this.beanNameExpression = new LiteralExpression<>(beanNameExpression);
+		Expression<String> expression;
+		try {
+			expression = ParameterMacroExpressionParser.INSTANCE.parse(beanNameExpression, String.class);
+		}
+		catch (ParseException ex) {
+			expression = new LiteralExpression<>(beanNameExpression);
+		}
+		this.beanNameExpression = expression;
 	}
 
 	@Override

--- a/coherence-spring-core/src/test/java/com/oracle/coherence/spring/configuration/CoherenceNamedCacheConfigurationNamedMapAnnotationTests.java
+++ b/coherence-spring-core/src/test/java/com/oracle/coherence/spring/configuration/CoherenceNamedCacheConfigurationNamedMapAnnotationTests.java
@@ -35,7 +35,6 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @SpringJUnitConfig(CoherenceNamedCacheConfigurationNamedMapAnnotationTests.Config.class)
@@ -84,13 +83,11 @@ class CoherenceNamedCacheConfigurationNamedMapAnnotationTests {
 		assertThat(bean.getDefaultCcfNumbers().getName(), is("numbers"));
 		assertThat(bean.getDefaultCcfAsyncNumbers(), is(notNullValue()));
 		assertThat(bean.getDefaultCcfAsyncNumbers().getNamedMap().getName(), is("numbers"));
-		assertThat(bean.getDefaultCcfAsyncNumbers().getNamedMap(), is(bean.getDefaultCcfNumbers()));
 
 		assertThat(bean.getSpecificCcfNumbers(), is(notNullValue()));
 		assertThat(bean.getSpecificCcfNumbers().getName(), is("numbers"));
 		assertThat(bean.getSpecificCcfAsyncNumbers(), is(notNullValue()));
 		assertThat(bean.getSpecificCcfAsyncNumbers().getNamedMap().getName(), is("numbers"));
-		assertThat(bean.getSpecificCcfAsyncNumbers().getNamedMap(), is(bean.getSpecificCcfNumbers()));
 
 		assertThat(bean.getDefaultCcfNumbers(), is(not(bean.getSpecificCcfNumbers())));
 	}
@@ -142,7 +139,6 @@ class CoherenceNamedCacheConfigurationNamedMapAnnotationTests {
 		CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean bean = this.ctx.getBean(CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean.class);
 		CacheMap map = bean.getCacheMap();
 		assertThat(map, is(notNullValue()));
-		assertThat(map, is(sameInstance(bean.getNamedMap())));
 	}
 
 	@Test
@@ -150,7 +146,6 @@ class CoherenceNamedCacheConfigurationNamedMapAnnotationTests {
 		CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean bean = this.ctx.getBean(CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean.class);
 		ConcurrentMap map = bean.getConcurrentMap();
 		assertThat(map, is(notNullValue()));
-		assertThat(map, is(sameInstance(bean.getNamedMap())));
 	}
 
 	@Test
@@ -158,7 +153,6 @@ class CoherenceNamedCacheConfigurationNamedMapAnnotationTests {
 		CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean bean = this.ctx.getBean(CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean.class);
 		InvocableMap map = bean.getInvocableMap();
 		assertThat(map, is(notNullValue()));
-		assertThat(map, is(sameInstance(bean.getNamedMap())));
 	}
 
 	@Test
@@ -166,7 +160,6 @@ class CoherenceNamedCacheConfigurationNamedMapAnnotationTests {
 		CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean bean = this.ctx.getBean(CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean.class);
 		ObservableMap map = bean.getObservableMap();
 		assertThat(map, is(notNullValue()));
-		assertThat(map, is(sameInstance(bean.getNamedMap())));
 	}
 
 	@Test
@@ -174,7 +167,6 @@ class CoherenceNamedCacheConfigurationNamedMapAnnotationTests {
 		CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean bean = this.ctx.getBean(CoherenceNamedCacheConfigurationNamedMapAnnotationTests.SuperTypesBean.class);
 		QueryMap map = bean.getQueryMap();
 		assertThat(map, is(notNullValue()));
-		assertThat(map, is(sameInstance(bean.getNamedMap())));
 	}
 
 	@Test

--- a/coherence-spring-core/src/test/resources/coherence-server-junit-extension-cache-config.xml
+++ b/coherence-spring-core/src/test/resources/coherence-server-junit-extension-cache-config.xml
@@ -2,7 +2,7 @@
 <!--
   Copyright (c) 2000, 2020, Oracle and/or its affiliates.
   Licensed under the Universal Permissive License v 1.0 as shown at
-  http://oss.oracle.com/licenses/upl.
+  https://oss.oracle.com/licenses/upl.
 -->
 
 <!--

--- a/coherence-spring-data/pom.xml
+++ b/coherence-spring-data/pom.xml
@@ -23,7 +23,6 @@
 
 	<properties>
 		<coherence.spring.root>${basedir}/..</coherence.spring.root>
-		<spring.data.version>2.5.0</spring.data.version>
 	</properties>
 
 	<build>
@@ -67,7 +66,6 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-commons</artifactId>
-			<version>${spring.data.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/coherence-spring-docs/src/main/asciidoc/core.adoc
+++ b/coherence-spring-docs/src/main/asciidoc/core.adoc
@@ -267,6 +267,12 @@ the name of the Coherence session as part of the annotation. E.g., the above exa
 <1> If not specified, the name of the field will be used to determine the cache name
 <2> Alternatively, you can specify the name of the cache using the `@Name` annotation
 
+[IMPORTANT]
+====
+All the annotations `@CoherenceCache`, `@CoherenceMap`, `@CoherenceAsyncCache`, and `@CoherenceAsyncMap` are themselves annotated with `@Lazy`. This is to avoid deadlocks where a cache bean requires another bean to be injected in its configuration, which will happen on a different thread to the main Spring thread.
+A consequence of this is that all cache beans will be Spring lazy dynamic proxies.
+====
+
 ==== Specify the Map/Cache Name
 
 As already mentioned above, you specify the name of the map/cache using the value-property of the annotation. Of course,

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
 		<!-- dependency versions (alphabetically) -->
 		<assertj.version>3.18.1</assertj.version>
 		<awaitility.version>4.0.3</awaitility.version>
-		<bedrock.version>5.1.1</bedrock.version>
+		<bedrock.version>5.1.2</bedrock.version>
 		<coherence.version>21.06</coherence.version>
 		<classgraph.version>4.8.102</classgraph.version>
 		<hamcrest.version>2.2</hamcrest.version>
@@ -161,6 +161,7 @@
 		<log4j.version>2.14.1</log4j.version>
 		<mockito.version>1.10.19</mockito.version>
 		<org.springframework.version>5.3.8</org.springframework.version>
+		<org.springframework.data.version>2021.0.4</org.springframework.data.version>
 		<reactor.version>3.4.6</reactor.version>
 		<spring-boot.version>2.5.2</spring-boot.version>
 		<spring-session.version>2.4.3</spring-session.version>
@@ -207,6 +208,13 @@
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-framework-bom</artifactId>
 				<version>${org.springframework.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-bom</artifactId>
+				<version>${org.springframework.data.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/samples/cachestore-demo/README.adoc
+++ b/samples/cachestore-demo/README.adoc
@@ -68,7 +68,7 @@ include::src/main/resources/coherence-cache-config.xml[tag=mapping]
 ----
 
 In the mapping above, the cache name `people` maps to the scheme `db-scheme` that we created above.
-As we mentioned above, we need to pass the actual bean name in the `repository-bean` parameter, which we do using `<init-params>` in the mapping. We set the `<param-value>` element to the bean name, in this case `personRepository`.
+As we mentioned above, we need to pass the actual bean name in the `repository-bean` parameter, which we do by using the `<init-params>` element in the mapping. We set the `<param-value>` element to the bean name, in this case `personRepository`.
 
 [NOTE]
 ====

--- a/samples/cachestore-demo/README.adoc
+++ b/samples/cachestore-demo/README.adoc
@@ -1,0 +1,154 @@
+= Coherence Spring JPA Repository CacheStore Demo
+
+In this demo we are show-casing how to use Spring Data JPA repository beans as Coherence CacheStores in
+applications using the https://github.com/coherence-community/coherence-spring[Coherence Spring project].
+
+Spring Data's https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#jpa.repositories[JPA Repositories] make basic CRUD database access very simple. An application developer can just provide an interface that extends `JpaRepository` with the required generic parameters and Spring will do the rest.
+
+Coherence caches that are backed by a database have two options for how the database integration is provided:
+
+* `CacheLoader` - an application developer writes an implementation of a `CacheLoader` to read data from a database for a given key (or keys), convert it to entities that are then loaded into a cache for the given keys.
+* `CacheStore` - whilst a `CacheLoader` only loads from a database into a cache, a `CacheStore` (which extends `CacheLoader`) also stores cached entities back to the database, or for entries deleted from the cache, erases the corresponding values from the database.
+
+The parallels between a `CacheLoader` or `CacheStore` and a `JpaRepository` should be pretty obvious.
+
+The Coherence Spring core module provides two interfaces, `com.oracle.coherence.spring.cachestore.JpaRepositoryCacheLoader`, which extends both `JpaRepository` and `CacheLoader` and `com.oracle.coherence.spring.cachestore.JpaRepositoryCacheStore`, which extends both `JpaRepository` and `CacheStore`. To create a JPA repository cache loader or cache store, all a developer needs to do is extend the relevant interface `JpaRepositoryCacheLoader` or `JpaRepositoryCacheStore` with the correct generic parameters.
+
+In this sample we have a simple class called `Person` annotated with JPA annotations:
+[source,java]
+----
+include::src/main/java/com/oracle/coherence/spring/example/model/Person.java[tag=person]
+----
+
+The identifier of a `Person` is defined as a `Long` so in our Coherence application we would put these `Person` instances into a Coherence `NamedMap<Long, Person>`.
+
+== Writing a JPA Repository CacheStore
+
+To write a JPA repository `CacheStore` that can be used by our people cache we just need to write a simple Spring Data repository interface:
+
+[source,java]
+----
+include::src/main/java/com/oracle/coherence/spring/example/model/PersonRepository.java[tag=imports]
+
+include::src/main/java/com/oracle/coherence/spring/example/model/PersonRepository.java[tag=personRepo]
+----
+
+That is all the code required to write a `CacheStore` that can be plugged into Coherence. Spring Data will take care of actually generating the implementation of the interface, and supplying that implementation as a bean.
+
+== Configure the CacheStore in Coherence
+
+To use a `CacheStore` in Coherence it needs to be configured in the Coherence cache configuration file.
+To use the repository bean as a `CacheStore` we will make use of the Coherence Spring feature that allows injection of Spring beans into the cache configuration file.
+
+To use Spring bean injection in the configuration file we need to declare the custom namespace in the root XML element.
+
+[source,xml]
+.coherence-cache-config.xml
+----
+include::src/main/resources/coherence-cache-config.xml[tag=header]
+----
+
+The `xmlns:spring="class://com.oracle.coherence.spring.namespace.NamespaceHandler"` line declares the custom namespace, so elements with a prefix `spring` will be handled by the `com.oracle.coherence.spring.namespace.NamespaceHandler` class. The custom namespace handler allows us to use elements of the form `<spring:bean>bean-name</spring:bean>` anywhere in the configuration that Coherence normally allows an `<instance>` element or a `<class-scheme>` element.
+
+We can add a scheme to the `<cache-schemes>` section of the configuration that uses the repository bean.
+[source,xml]
+.coherence-cache-config.xml
+----
+include::src/main/resources/coherence-cache-config.xml[tag=scheme]
+----
+
+In the snippet above you can see the `<spring:bean>{repository-bean}</spring:bean>` element used as the cache store.
+In this case we have not used the name of the repository bean directly, we have used a parameter named `repository-bean` (XML values in curly-brackets in the `<spring:bean>` element are treated as parameter macros). This allows us to map multiple caches to the same scheme each with a different cache store - this is quite a common approach in Coherence for a number of elements that may be configured in a scheme per-cache.
+
+We can also now add the cache mapping for our `people` cache that will use the scheme above.
+[source,xml]
+.coherence-cache-config.xml
+----
+include::src/main/resources/coherence-cache-config.xml[tag=mapping]
+----
+
+In the mapping above, the cache name `people` maps to the scheme `db-scheme` that we created above.
+As we mentioned above, we need to pass the actual bean name in the `repository-bean` parameter, which we do using `<init-params>` in the mapping. We set the `<param-value>` element to the bean name, in this case `personRepository`.
+
+[NOTE]
+====
+The bean name use here is `personRepository`. This is the default name generated by Spring for the `PersonRepository` class, which is the simple class name with the first letter lowercase. If we did not want to rely on Spring generating a bean name we could specify a name in the `@Repository` annotation on the `PersonRepository` class.
+====
+
+If we had another cache with a different cache store, for example if we had an entity called `Location` with a repository cache store class called `LocationRepository`, the bean name would default to `locationRepository`, and we could add the following mapping.
+[source,xml]
+----
+        <cache-mapping>
+            <cache-name>locations</cache-name>
+            <scheme-name>db-scheme</scheme-name>
+            <init-params>
+                <init-param>
+                    <param-name>repository-bean</param-name>
+                    <param-value>locationRepository</param-value>
+                </init-param>
+            </init-params>
+        </cache-mapping>
+----
+
+== Running the Sample
+
+This sample is just a simple Spring Boot application that exposes two endpoints to create/update people and get people by id.
+
+The controller class is very simple:
+[source,java]
+.PersonController.java
+----
+include::src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java[tag=code]
+----
+
+We use the Coherence Spring integration to inject a `NamedMap` into the controller. This will be for the cache named `people`, which we configured to use the cache store in the configuration above.
+
+In the `createPerson` method we use the request parameters to create a `Person` and put it into the cache. The `CacheStore` will write this to the database.
+
+In the `getPerson` method we retrieve the `Person` from the cache using the id from the request path, loading from the database if there is no entry in the cache for the id.
+
+We can build the example using Maven from the cache store sample root directory:
+[source,bash]
+----
+mvn clean package
+----
+
+This will build a Spring Boot jar that we can run the normal Spring Boot ways, for example:
+[source,bash]
+----
+java -jar coherence-spring-cachestore-demo-3.0.0-SNAPSHOT.jar
+----
+
+After the application has started we can try to get a `Person` using `curl`
+[source,bash]
+----
+curl -i -X GET http://localhost:8080/api/people/100
+----
+This should return a 404 response because there is no person in the database or cache with the id 100.
+
+We can create a `Person` using a `curl` POST request:
+[source,bash]
+----
+curl -i -X POST http://localhost:8080/api/people \
+    -d 'firstName=Joe' -d 'lastName=Smith' \
+    -d 'age=21' -d 'id=100'
+----
+This will create the `Person` named Joe Smith with the id 100. This should return with a 200 response to say the `Person` was successfully created and will be stored in the database.
+
+If we re-run the GET request we should get Joe Smith.
+[source,bash]
+----
+curl -i -X GET http://localhost:8080/api/people/100
+HTTP/1.1 200
+Content-Type: application/json
+Transfer-Encoding: chunked
+Date: Thu, 19 Aug 2021 16:13:47 GMT
+
+{"id":100,"age":21,"firstname":"Joe","lastname":"Smith"}%
+----
+
+
+
+
+
+

--- a/samples/cachestore-demo/pom.xml
+++ b/samples/cachestore-demo/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.oracle.coherence.spring</groupId>
+		<artifactId>samples</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>coherence-spring-cachestore-demo</artifactId>
+
+	<name>Coherence Spring CacheStore Demo</name>
+	<description>Coherence Spring CacheStore Demo</description>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${spring-boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.oracle.coherence.ce</groupId>
+			<artifactId>coherence</artifactId>
+			<version>${coherence.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.coherence.spring</groupId>
+			<artifactId>coherence-spring-boot-starter</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.bedrock.coherence</groupId>
+			<artifactId>coherence-14.1.1-testing-support</artifactId>
+			<version>${bedrock.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${spring-boot.version}</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/CacheStoreDemo.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/CacheStoreDemo.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates.
+ * Copyright (c) 2021, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
- * http://oss.oracle.com/licenses/upl.
+ * https://oss.oracle.com/licenses/upl.
  */
 package com.oracle.coherence.spring.example;
 

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/CacheStoreDemo.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/CacheStoreDemo.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+package com.oracle.coherence.spring.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Entry point to the Coherence Cache Store Demo Application.
+ *
+ * @author Jonathan Knight 2021.08.17
+ */
+@SpringBootApplication
+public class CacheStoreDemo {
+
+	public static void main(String[] args) {
+		SpringApplication.run(CacheStoreDemo.class, args);
+	}
+
+}

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates.
+ * Copyright (c) 2021, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
- * http://oss.oracle.com/licenses/upl.
+ * https://oss.oracle.com/licenses/upl.
  */
 package com.oracle.coherence.spring.example.controller;
 

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java
@@ -6,12 +6,10 @@
  */
 package com.oracle.coherence.spring.example.controller;
 
-import com.oracle.coherence.spring.configuration.annotation.CoherenceCache;
 import com.oracle.coherence.spring.configuration.annotation.CoherenceMap;
 import com.oracle.coherence.spring.example.model.Person;
-import com.tangosol.net.NamedCache;
+import com.tangosol.net.NamedMap;
 
-import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,16 +25,17 @@ import org.springframework.web.server.ResponseStatusException;
  *
  * @author Jonathan Knight 2021.08.17
  */
+// # tag::code[]
 @RestController
 @RequestMapping(path = "/api/people")
 @Transactional()
 public class PersonController {
 
 	/**
-	 * The {@link NamedCache} to store {@link Person} entities.
+	 * The {@link NamedMap} to store {@link Person} entities.
 	 */
 	@CoherenceMap
-	private NamedCache<Long, Person> people;
+	private NamedMap<Long, Person> people;
 
 	/**
 	 * Create a {@link Person} in the cache.
@@ -74,3 +73,4 @@ public class PersonController {
 	}
 
 }
+// # end::code[]

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java
@@ -7,6 +7,7 @@
 package com.oracle.coherence.spring.example.controller;
 
 import com.oracle.coherence.spring.configuration.annotation.CoherenceCache;
+import com.oracle.coherence.spring.configuration.annotation.CoherenceMap;
 import com.oracle.coherence.spring.example.model.Person;
 import com.tangosol.net.NamedCache;
 
@@ -34,8 +35,7 @@ public class PersonController {
 	/**
 	 * The {@link NamedCache} to store {@link Person} entities.
 	 */
-	@Lazy
-	@CoherenceCache
+	@CoherenceMap
 	private NamedCache<Long, Person> people;
 
 	/**

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/controller/PersonController.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+package com.oracle.coherence.spring.example.controller;
+
+import com.oracle.coherence.spring.configuration.annotation.CoherenceCache;
+import com.oracle.coherence.spring.example.model.Person;
+import com.tangosol.net.NamedCache;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Explicit controller API for People.
+ *
+ * @author Jonathan Knight 2021.08.17
+ */
+@RestController
+@RequestMapping(path = "/api/people")
+@Transactional()
+public class PersonController {
+
+	/**
+	 * The {@link NamedCache} to store {@link Person} entities.
+	 */
+	@Lazy
+	@CoherenceCache
+	private NamedCache<Long, Person> people;
+
+	/**
+	 * Create a {@link Person} in the cache.
+	 * @param id         the unique identifier for the person
+	 * @param firstName  the person's first name
+	 * @param lastName   the person's last name
+	 * @param age        the person's age
+	 * @return the identifier used to create the person
+	 */
+	@PostMapping
+	public Long createPerson(@RequestParam("id") long id, @RequestParam("firstName") String firstName,
+			@RequestParam("lastName") String lastName, @RequestParam("age") int age) {
+		Person person = new Person();
+		person.setFirstname(firstName);
+		person.setLastname(lastName);
+		person.setAge(age);
+		person.setId(id);
+		people.put(id, person);
+		return id;
+	}
+
+	/**
+	 * Returns the {@link Person} with the specified identifier.
+	 *
+	 * @param personId  the unique identifier for the person
+	 * @return  the {@link Person} with the specified identifier
+	 */
+	@GetMapping("/{personId}")
+	public Person getPerson(@PathVariable("personId") Long personId) {
+		Person person = people.get(personId);
+		if (person == null) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Person " + personId + " does not exist");
+		}
+		return person;
+	}
+
+}

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/Person.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/Person.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates.
+ * Copyright (c) 2021, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
- * http://oss.oracle.com/licenses/upl.
+ * https://oss.oracle.com/licenses/upl.
  */
 package com.oracle.coherence.spring.example.model;
 

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/Person.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/Person.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+package com.oracle.coherence.spring.example.model;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+
+import com.tangosol.io.pof.schema.annotation.Portable;
+import com.tangosol.io.pof.schema.annotation.PortableType;
+
+/**
+ * A simple representation of a person.
+ *
+ * @author Jonathan Knight 2021.08.17
+ */
+@Entity
+@Table(name = "PEOPLE")
+@PortableType(id = 1000)
+public class Person implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The unique identifier for this person.
+	 */
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	@Portable
+	private Long id;
+
+	/**
+	 * The age of this person.
+	 */
+	@Portable
+	private int age;
+
+	/**
+	 * The person's first name.
+	 */
+	@Portable
+	private String firstname;
+
+	/**
+	 * The person's last name.
+	 */
+	@Portable
+	private String lastname;
+
+	/**
+	 * The email addresses associated to this person.
+	 */
+	@ElementCollection(fetch = FetchType.EAGER)
+	@CollectionTable(name = "PERSON_EMAIL_ADDR", joinColumns = @JoinColumn(name = "PERSON_ID"))
+	@Column(name = "EMAIL_ADDR")
+	@Portable
+	private Set<String> emailAddresses = new HashSet<>();
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public int getAge() {
+		return age;
+	}
+
+	public void setAge(int age) {
+		this.age = age;
+	}
+
+	public String getFirstname() {
+		return firstname;
+	}
+
+	public void setFirstname(String firstname) {
+		this.firstname = firstname;
+	}
+
+	public String getLastname() {
+		return lastname;
+	}
+
+	public void setLastname(String lastname) {
+		this.lastname = lastname;
+	}
+
+	public Set<String> getEmailAddresses() {
+		return emailAddresses;
+	}
+
+	public void setEmailAddresses(Set<String> emailAddresses) {
+		this.emailAddresses = emailAddresses;
+	}
+
+}

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/Person.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/Person.java
@@ -7,69 +7,43 @@
 package com.oracle.coherence.spring.example.model;
 
 import java.io.Serializable;
-import java.util.HashSet;
-import java.util.Set;
 
-import javax.persistence.CollectionTable;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.Table;
-
-import com.tangosol.io.pof.schema.annotation.Portable;
-import com.tangosol.io.pof.schema.annotation.PortableType;
 
 /**
  * A simple representation of a person.
  *
  * @author Jonathan Knight 2021.08.17
  */
+// # tag::person[]
 @Entity
 @Table(name = "PEOPLE")
-@PortableType(id = 1000)
 public class Person implements Serializable {
-
-	private static final long serialVersionUID = 1L;
 
 	/**
 	 * The unique identifier for this person.
 	 */
 	@Id
-	@GeneratedValue(strategy = GenerationType.AUTO)
-	@Portable
 	private Long id;
 
 	/**
 	 * The age of this person.
 	 */
-	@Portable
 	private int age;
 
 	/**
 	 * The person's first name.
 	 */
-	@Portable
 	private String firstname;
 
 	/**
 	 * The person's last name.
 	 */
-	@Portable
 	private String lastname;
-
-	/**
-	 * The email addresses associated to this person.
-	 */
-	@ElementCollection(fetch = FetchType.EAGER)
-	@CollectionTable(name = "PERSON_EMAIL_ADDR", joinColumns = @JoinColumn(name = "PERSON_ID"))
-	@Column(name = "EMAIL_ADDR")
-	@Portable
-	private Set<String> emailAddresses = new HashSet<>();
 
 	public Long getId() {
 		return id;
@@ -103,12 +77,5 @@ public class Person implements Serializable {
 		this.lastname = lastname;
 	}
 
-	public Set<String> getEmailAddresses() {
-		return emailAddresses;
-	}
-
-	public void setEmailAddresses(Set<String> emailAddresses) {
-		this.emailAddresses = emailAddresses;
-	}
-
 }
+// # end::person[]

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/PersonRepository.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/PersonRepository.java
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates.
+ * Copyright (c) 2021, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
- * http://oss.oracle.com/licenses/upl.
+ * https://oss.oracle.com/licenses/upl.
  */
 package com.oracle.coherence.spring.example.model;
 

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/PersonRepository.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/PersonRepository.java
@@ -6,8 +6,10 @@
  */
 package com.oracle.coherence.spring.example.model;
 
+// # tag::imports[]
 import com.oracle.coherence.spring.cachestore.JpaRepositoryCacheStore;
 import org.springframework.stereotype.Repository;
+// # end::imports[]
 
 /**
  * A JPA repository cache store for the {@link Person} entity.
@@ -16,7 +18,9 @@ import org.springframework.stereotype.Repository;
  *
  * @author Jonathan Knight 2021.08.17
  */
+// # tag::personRepo[]
 @Repository
 public interface PersonRepository extends JpaRepositoryCacheStore<Person, Long> {
 
 }
+// # end::personRepo[]

--- a/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/PersonRepository.java
+++ b/samples/cachestore-demo/src/main/java/com/oracle/coherence/spring/example/model/PersonRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * http://oss.oracle.com/licenses/upl.
+ */
+package com.oracle.coherence.spring.example.model;
+
+import com.oracle.coherence.spring.cachestore.JpaRepositoryCacheStore;
+import org.springframework.stereotype.Repository;
+
+/**
+ * A JPA repository cache store for the {@link Person} entity.
+ *
+ * <b>Note:</b> The bean must be given a name
+ *
+ * @author Jonathan Knight 2021.08.17
+ */
+@Repository
+public interface PersonRepository extends JpaRepositoryCacheStore<Person, Long> {
+
+}

--- a/samples/cachestore-demo/src/main/resources/application.yml
+++ b/samples/cachestore-demo/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+debug: false
+coherence:
+  logging:
+    destination: slf4j
+    severity-level: 6
+spring:
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate.show_sql: false
+      hibernate.use_sql_comments: false
+      hibernate.format_sql: true
+

--- a/samples/cachestore-demo/src/main/resources/application.yml
+++ b/samples/cachestore-demo/src/main/resources/application.yml
@@ -12,4 +12,3 @@ spring:
       hibernate.show_sql: false
       hibernate.use_sql_comments: false
       hibernate.format_sql: true
-

--- a/samples/cachestore-demo/src/main/resources/coherence-cache-config.xml
+++ b/samples/cachestore-demo/src/main/resources/coherence-cache-config.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<!--
+  Copyright (c) 2021, Oracle and/or its affiliates.
+  Licensed under the Universal Permissive License v 1.0 as shown at
+  http://oss.oracle.com/licenses/upl.
+-->
+<cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"
+              xmlns:spring="class://com.oracle.coherence.spring.namespace.NamespaceHandler"
+              xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-cache-config coherence-cache-config.xsd">
+
+    <caching-scheme-mapping>
+        <cache-mapping>
+            <cache-name>people</cache-name>
+            <scheme-name>db-scheme</scheme-name>
+            <init-params>
+                <init-param>
+                    <param-name>repository-bean</param-name>
+                    <param-value>personRepository</param-value>
+                </init-param>
+            </init-params>
+        </cache-mapping>
+
+        <cache-mapping>
+            <cache-name>*</cache-name>
+            <scheme-name>storage-scheme</scheme-name>
+        </cache-mapping>
+    </caching-scheme-mapping>
+
+    <caching-schemes>
+        <distributed-scheme>
+            <scheme-name>db-scheme</scheme-name>
+            <scheme-ref>storage-scheme</scheme-ref>
+            <backing-map-scheme>
+                <read-write-backing-map-scheme>
+                    <internal-cache-scheme>
+                        <local-scheme>
+                        </local-scheme>
+                    </internal-cache-scheme>
+                    <cachestore-scheme>
+                        <spring:bean>{repository-bean}</spring:bean>
+                    </cachestore-scheme>
+                </read-write-backing-map-scheme>
+            </backing-map-scheme>
+            <autostart>true</autostart>
+        </distributed-scheme>
+
+        <distributed-scheme>
+            <scheme-name>storage-scheme</scheme-name>
+            <service-name>StorageService</service-name>
+            <backing-map-scheme>
+                <local-scheme/>
+            </backing-map-scheme>
+            <autostart>true</autostart>
+        </distributed-scheme>
+
+        <!-- proxy scheme that allows extend clients to connect to the cluster over TCP/IP -->
+        <proxy-scheme>
+            <service-name>Proxy</service-name>
+            <acceptor-config>
+                <tcp-acceptor>
+                    <local-address>
+                        <address system-property="coherence.extend.address">0.0.0.0</address>
+                        <port system-property="coherence.extend.port">20000</port>
+                    </local-address>
+                </tcp-acceptor>
+            </acceptor-config>
+            <autostart>true</autostart>
+        </proxy-scheme>
+    </caching-schemes>
+</cache-config>

--- a/samples/cachestore-demo/src/main/resources/coherence-cache-config.xml
+++ b/samples/cachestore-demo/src/main/resources/coherence-cache-config.xml
@@ -4,12 +4,15 @@
   Licensed under the Universal Permissive License v 1.0 as shown at
   http://oss.oracle.com/licenses/upl.
 -->
+<!-- # tag::header[] -->
 <cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"
               xmlns:spring="class://com.oracle.coherence.spring.namespace.NamespaceHandler"
               xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-cache-config coherence-cache-config.xsd">
+<!-- # end::header[] -->
 
     <caching-scheme-mapping>
+        <!-- # tag::mapping[] -->
         <cache-mapping>
             <cache-name>people</cache-name>
             <scheme-name>db-scheme</scheme-name>
@@ -20,22 +23,18 @@
                 </init-param>
             </init-params>
         </cache-mapping>
-
-        <cache-mapping>
-            <cache-name>*</cache-name>
-            <scheme-name>storage-scheme</scheme-name>
-        </cache-mapping>
+        <!-- # end::mapping[] -->
     </caching-scheme-mapping>
 
+<!-- # tag::scheme[] -->
     <caching-schemes>
         <distributed-scheme>
             <scheme-name>db-scheme</scheme-name>
-            <scheme-ref>storage-scheme</scheme-ref>
+            <service-name>StorageService</service-name>
             <backing-map-scheme>
                 <read-write-backing-map-scheme>
                     <internal-cache-scheme>
-                        <local-scheme>
-                        </local-scheme>
+                        <local-scheme/>
                     </internal-cache-scheme>
                     <cachestore-scheme>
                         <spring:bean>{repository-bean}</spring:bean>
@@ -44,15 +43,7 @@
             </backing-map-scheme>
             <autostart>true</autostart>
         </distributed-scheme>
-
-        <distributed-scheme>
-            <scheme-name>storage-scheme</scheme-name>
-            <service-name>StorageService</service-name>
-            <backing-map-scheme>
-                <local-scheme/>
-            </backing-map-scheme>
-            <autostart>true</autostart>
-        </distributed-scheme>
+<!-- # end::scheme[] -->
 
         <!-- proxy scheme that allows extend clients to connect to the cluster over TCP/IP -->
         <proxy-scheme>

--- a/samples/cachestore-demo/src/main/resources/coherence-cache-config.xml
+++ b/samples/cachestore-demo/src/main/resources/coherence-cache-config.xml
@@ -2,7 +2,7 @@
 <!--
   Copyright (c) 2021, Oracle and/or its affiliates.
   Licensed under the Universal Permissive License v 1.0 as shown at
-  http://oss.oracle.com/licenses/upl.
+  https://oss.oracle.com/licenses/upl.
 -->
 <!-- # tag::header[] -->
 <cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/CacheStoreDemoIT.java
+++ b/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/CacheStoreDemoIT.java
@@ -1,0 +1,240 @@
+package com.oracle.coherence.spring.example;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.oracle.bedrock.runtime.LocalPlatform;
+import com.oracle.bedrock.runtime.coherence.CoherenceClusterMember;
+import com.oracle.bedrock.runtime.coherence.callables.IsServiceRunning;
+import com.oracle.bedrock.runtime.java.ClassPath;
+import com.oracle.bedrock.runtime.java.JavaApplication;
+import com.oracle.bedrock.runtime.java.options.ClassName;
+import com.oracle.bedrock.runtime.java.options.SystemProperty;
+import com.oracle.bedrock.runtime.options.Arguments;
+import com.oracle.bedrock.runtime.options.DisplayName;
+import com.oracle.bedrock.runtime.options.WorkingDirectory;
+import com.oracle.bedrock.testsupport.MavenProjectFileUtils;
+import com.oracle.bedrock.testsupport.deferred.Eventually;
+import com.oracle.bedrock.testsupport.junit.TestLogsExtension;
+import com.oracle.coherence.spring.example.model.Person;
+import com.oracle.coherence.spring.example.model.PersonRepository;
+import com.tangosol.net.Coherence;
+import com.tangosol.net.CoherenceConfiguration;
+import com.tangosol.net.NamedCache;
+import com.tangosol.net.Session;
+import com.tangosol.net.SessionConfiguration;
+import org.hsqldb.Server;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * This test starts HSQLDB in an external process and then starts the {@link CacheStoreDemo}
+ * Spring Boot application in another external process. The test then starts a Coherence Extend
+ * client session that connects to the {@link Person} cache and performs puts and gets on the cache.
+ * The test then verifies the state of the database to assert that the JPA cache store worked correctly.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(SpringExtension.class)
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, })
+public class CacheStoreDemoIT {
+
+	/**
+	 * Repository bean injected by Spring.
+	 */
+	@Autowired
+	private PersonRepository repository;
+
+	/**
+	 * The HSQLDB process started by Bedrock.
+	 */
+    static JavaApplication hsqldb;
+
+	/**
+	 * The {@link CacheStoreDemo} application started by Bedrock.
+	 */
+	static CoherenceClusterMember server;
+
+	/**
+	 * The Coherence {@link Session} to use for getting test caches.
+	 */
+	private static Session session;
+
+	/**
+	 * A JUnit5 extension to capture logs from processes started by Bedrock.
+	 */
+    @RegisterExtension
+    static TestLogsExtension testLogs = new TestLogsExtension(CacheStoreDemoIT.class);
+
+	/**
+	 * Field used to ensure that different tests use different IDs for departments.
+	 */
+	static AtomicLong id = new AtomicLong(1L);
+
+	@BeforeAll
+	static void setup() throws Exception {
+		File outputDir = MavenProjectFileUtils.ensureTestOutputFolder(CacheStoreDemoIT.class, null);
+		File dbDir = new File(outputDir, "hsqldb");
+
+		// clean-up any previous database files from old tests
+		MavenProjectFileUtils.recursiveDelete(dbDir);
+		// re-create the db folder
+		assertThat(dbDir.mkdirs(), is(true));
+		assertThat(dbDir.exists(), is(true));
+		assertThat(dbDir.isDirectory(), is(true));
+
+		// Run db processes on the local machine
+		LocalPlatform platform = LocalPlatform.get();
+
+		testLogs.init(CacheStoreDemoIT.class, "logs");
+
+		// Start the HSQLDB listening on port 9001
+		hsqldb = platform.launch(JavaApplication.class,
+				ClassName.of(Server.class),
+				WorkingDirectory.at(dbDir),
+				testLogs,
+				ClassPath.ofClass(Server.class),
+				Arguments.of("--database.0", "file:testdb", "--dbname.0", "testdb", "--port", 9001),
+				DisplayName.of("HSQLDB"));
+
+		// Start the Coherence demo server
+		server = platform.launch(CoherenceClusterMember.class,
+				ClassName.of(CacheStoreDemo.class),
+				testLogs,
+				SystemProperty.of("spring.jmx.enabled", true),
+				DisplayName.of("server"));
+
+		// Wait for Spring to start
+		Eventually.assertDeferred(() -> server.invoke(IsSpringUp.INSTANCE), is(true));
+		// Ensure the Coherence Extend proxy has started
+		Eventually.assertDeferred(() -> server.invoke(new IsServiceRunning("Proxy")), is(true));
+
+		// Create the local Coherence Extend client
+		CoherenceConfiguration config = CoherenceConfiguration.builder()
+				.withSession(SessionConfiguration.create("client-cache-config.xml")).build();
+		Coherence coherence = Coherence.client(config);
+		// wait at most 1 minute for the Coherence DefaultCacheServer to start
+		// DefaultCacheServer is started automatically by the application but for the
+		// tests to pass we need to ensure it has finished starting cache services.
+		coherence.start().get(1, TimeUnit.MINUTES);
+
+		// Create the Coherence Session using the client cache configuration that will connect over Extend.
+		session = coherence.getSession();
+	}
+
+	@AfterAll
+	static void cleanup() {
+		if (hsqldb != null) {
+			hsqldb.close();
+		}
+		if (server != null) {
+			server.close();
+		}
+	}
+
+	/**
+	 * This test will cause a cache store load which will be a miss as there is no
+	 * entry in the db for the key.
+	 */
+	@Test
+	public void shouldNotGetPersonNotInDB() {
+		NamedCache<Long, Person> cache = session.getCache("people");
+		Person result = cache.get(-1L);
+		assertThat(result, is(nullValue()));
+	}
+
+	/**
+	 * This test loads a Person into the db then gets it from the cache
+	 * which will cause a read-through from the db into the cache.
+	 */
+	@Test
+	public void shouldGetPersonInDB() {
+		Person person = new Person();
+		person.setId(id.getAndIncrement());
+		person.setFirstname("Foo");
+		person.setLastname("Bar");
+
+		person = repository.saveAndFlush(person);
+
+		NamedCache<Long, Person> departments = session.getCache("people");
+		Person result = departments.get(person.getId());
+		assertThat(result, is(notNullValue()));
+		assertThat(result.getFirstname(), is(person.getFirstname()));
+		assertThat(result.getLastname(), is(person.getLastname()));
+	}
+
+	/**
+	 * This test will add a person to the cache which will cause
+	 * a write-through to the db.
+	 */
+	@Test
+	public void shouldCreatePerson() {
+		Person person = new Person();
+		person.setId(id.getAndIncrement());
+		person.setFirstname("Foo");
+		person.setLastname("Bar");
+		person.setAge(21);
+
+		NamedCache<Long, Person> departments = session.getCache("people");
+		departments.put(person.getId(), person);
+
+		Optional<Person> byId = repository.findById(person.getId());
+		assertThat(byId.isPresent(), is(true));
+		Person result = byId.get();
+		assertThat(result.getFirstname(), is(person.getFirstname()));
+		assertThat(result.getLastname(), is(person.getLastname()));
+		assertThat(result.getAge(), is(person.getAge()));
+	}
+
+	/**
+	 * This test obtain a person from the cache that exists in the db
+	 * then put the updated person back into the cache causing a db update.
+	 */
+	@Test
+	public void shouldUpdatePerson() {
+		Person person = new Person();
+		person.setId(id.getAndIncrement());
+		person.setFirstname("Foo");
+		person.setLastname("Bar");
+		person.setAge(19);
+
+		person = repository.saveAndFlush(person);
+
+		NamedCache<Long, Person> cache = session.getCache("people");
+		Person cached = cache.get(person.getId());
+
+		assertThat(cached, is(notNullValue()));
+		assertThat(cached.getId(), is(person.getId()));
+		assertThat(cached.getFirstname(), is(person.getFirstname()));
+		assertThat(cached.getLastname(), is(person.getLastname()));
+		assertThat(cached.getAge(), is(19));
+
+		cached.setAge(20);
+		cache.put(cached.getId(), cached);
+
+		Optional<Person> byId = repository.findById(person.getId());
+		assertThat(byId.isPresent(), is(true));
+		Person result = byId.get();
+		assertThat(result, is(notNullValue()));
+		assertThat(result.getAge(), is(20));
+	}
+
+}

--- a/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/CacheStoreDemoIT.java
+++ b/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/CacheStoreDemoIT.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
 package com.oracle.coherence.spring.example;
 
 import java.io.File;

--- a/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/CacheStoreDemoIT.java
+++ b/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/CacheStoreDemoIT.java
@@ -8,9 +8,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.oracle.bedrock.runtime.LocalPlatform;
 import com.oracle.bedrock.runtime.coherence.CoherenceClusterMember;
 import com.oracle.bedrock.runtime.coherence.callables.IsServiceRunning;
+import com.oracle.bedrock.runtime.coherence.options.LocalHost;
 import com.oracle.bedrock.runtime.java.ClassPath;
 import com.oracle.bedrock.runtime.java.JavaApplication;
 import com.oracle.bedrock.runtime.java.options.ClassName;
+import com.oracle.bedrock.runtime.java.options.IPv4Preferred;
 import com.oracle.bedrock.runtime.java.options.SystemProperty;
 import com.oracle.bedrock.runtime.options.Arguments;
 import com.oracle.bedrock.runtime.options.DisplayName;
@@ -113,6 +115,7 @@ public class CacheStoreDemoIT {
 				testLogs,
 				ClassPath.ofClass(Server.class),
 				Arguments.of("--database.0", "file:testdb", "--dbname.0", "testdb", "--port", 9001),
+				IPv4Preferred.yes(),
 				DisplayName.of("HSQLDB"));
 
 		// Start the Coherence demo server
@@ -120,6 +123,8 @@ public class CacheStoreDemoIT {
 				ClassName.of(CacheStoreDemo.class),
 				testLogs,
 				SystemProperty.of("spring.jmx.enabled", true),
+				LocalHost.only(),
+				IPv4Preferred.yes(),
 				DisplayName.of("server"));
 
 		// Wait for Spring to start

--- a/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/IsSpringUp.java
+++ b/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/IsSpringUp.java
@@ -1,0 +1,33 @@
+package com.oracle.coherence.spring.example;
+
+import java.util.Map;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import com.oracle.bedrock.runtime.concurrent.RemoteCallable;
+import com.tangosol.net.management.MBeanHelper;
+
+public class IsSpringUp implements RemoteCallable<Boolean> {
+
+    public static final IsSpringUp INSTANCE = new IsSpringUp();
+
+	@Override
+	@SuppressWarnings("rawtypes")
+	public Boolean call() throws Exception {
+		try {
+			MBeanServer server = MBeanHelper.findMBeanServer();
+			ObjectName name = new ObjectName("org.springframework.boot:type=Endpoint,name=Health");
+			Map map = (Map) server.invoke(name, "health", new Object[0], new String[0]);
+			String status = String.valueOf(map.get("status"));
+			return "UP".equalsIgnoreCase(status);
+		} catch (Throwable ex) {
+			return false;
+		}
+	}
+
+}

--- a/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/IsSpringUp.java
+++ b/samples/cachestore-demo/src/test/java/com/oracle/coherence/spring/example/IsSpringUp.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
 package com.oracle.coherence.spring.example;
 
 import java.util.Map;

--- a/samples/cachestore-demo/src/test/resources/application.yml
+++ b/samples/cachestore-demo/src/test/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.hsqldb.jdbc.JDBCDriver
+    url: jdbc:hsqldb:hsql://localhost/testdb
+    username: sa
+    password:
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate.show_sql: false
+      hibernate.use_sql_comments: false
+      hibernate.format_sql: true

--- a/samples/cachestore-demo/src/test/resources/client-cache-config.xml
+++ b/samples/cachestore-demo/src/test/resources/client-cache-config.xml
@@ -2,7 +2,7 @@
 <!--
   Copyright (c) 2021, Oracle and/or its affiliates.
   Licensed under the Universal Permissive License v 1.0 as shown at
-  http://oss.oracle.com/licenses/upl.
+  https://oss.oracle.com/licenses/upl.
 -->
 <cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"

--- a/samples/cachestore-demo/src/test/resources/client-cache-config.xml
+++ b/samples/cachestore-demo/src/test/resources/client-cache-config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+  Copyright (c) 2021, Oracle and/or its affiliates.
+  Licensed under the Universal Permissive License v 1.0 as shown at
+  http://oss.oracle.com/licenses/upl.
+-->
+<cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"
+        xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-cache-config coherence-cache-config.xsd">
+
+    <caching-scheme-mapping>
+        <cache-mapping>
+            <cache-name>*</cache-name>
+            <scheme-name>remote</scheme-name>
+        </cache-mapping>
+    </caching-scheme-mapping>
+
+    <caching-schemes>
+        <remote-cache-scheme>
+            <scheme-name>remote</scheme-name>
+            <service-name>RemoteCache</service-name>
+            <proxy-service-name>Proxy</proxy-service-name>
+            <initiator-config>
+                <tcp-initiator>
+                    <socket-provider>${coherence.extend.socket.provider tcp}</socket-provider>
+                    <remote-addresses>
+                        <socket-address>
+                            <address system-property="extend.host">127.0.0.1</address>
+                            <port system-property="extend.port">20000</port>
+                        </socket-address>
+                    </remote-addresses>
+                </tcp-initiator>
+            </initiator-config>
+        </remote-cache-scheme>
+    </caching-schemes>
+</cache-config>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -31,6 +31,7 @@
 		<module>coherence-spring-demo</module>
 		<module>hibernate-cache-demo</module>
 		<module>spring-session-demo</module>
+		<module>cachestore-demo</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
This PR allows customers to use JPA repository beans as Coherence `CacheLoader` or `CacheStore` implementations.

Two new interfaces have been added `JpaRepositoryCacheLoader` and `JpaRepositoryCacheStore` that extend `JpaRepository`.  To create a `CacheLoader` or `CacheStore`the customer just needs to create a new interface that extends one of those interfaces with the correct generic parameters and annotate it with `@Repository`. This  Spring will then do the rest. Using the Spring custom namespace in the cache configuration file, this new repository bean can then be injected as the cache store to use for a cache.

A sample has been added in `samples/cachestore-demo`.

Documentation to follow in an update to this PR.
