### PR TITLE
Update Coherence dependency to 21.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
 		<assertj.version>3.20.2</assertj.version>
 		<awaitility.version>4.1.0</awaitility.version>
 		<bedrock.version>5.1.3</bedrock.version>
-		<coherence.version>21.12.2</coherence.version>
+		<coherence.version>21.12.3</coherence.version>
 		<classgraph.version>4.8.115</classgraph.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<hsqldb.version>2.6.0</hsqldb.version>
@@ -165,10 +165,10 @@
 		<javax.servlet-api.version>3.1.0</javax.servlet-api.version>
 		<javax.inject.version>1</javax.inject.version>
 		<junit.version>5.7.2</junit.version>
-		<log4j.version>2.17.1</log4j.version>
+		<log4j.version>2.17.2</log4j.version>
 		<mockito.version>3.12.4</mockito.version>
-		<org.springframework.version>5.3.18</org.springframework.version>
-		<org.springframework.data.version>2021.1.1</org.springframework.data.version>
+		<org.springframework.version>5.3.19</org.springframework.version>
+		<org.springframework.data.version>2021.1.4</org.springframework.data.version>
 		<reactor.version>3.4.9</reactor.version>
 		<resilience4j.version>1.7.1</resilience4j.version>
 		<spring-boot.version>2.6.6</spring-boot.version>

--- a/samples/coherence-spring-demo/coherence-spring-demo-classic/pom.xml
+++ b/samples/coherence-spring-demo/coherence-spring-demo-classic/pom.xml
@@ -24,7 +24,7 @@
 	<properties>
 		<mainClass>com.oracle.coherence.spring.demo.tomcat.Server</mainClass>
 		<java.version>8</java.version>
-		<spring-data-bom.version>2021.1.1</spring-data-bom.version>
+		<spring-data-bom.version>2021.1.4</spring-data-bom.version>
 		<jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
 		<hibernate.version>5.6.4.Final</hibernate.version>
 		<jackson-datatype.version>2.13.2</jackson-datatype.version>

--- a/samples/coherence-spring-demo/coherence-spring-demo-core/pom.xml
+++ b/samples/coherence-spring-demo/coherence-spring-demo-core/pom.xml
@@ -26,7 +26,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<java.version>8</java.version>
-		<spring-data-bom.version>2021.1.1</spring-data-bom.version>
+		<spring-data-bom.version>2021.1.4</spring-data-bom.version>
 		<jakarta.persistence-api.version>2.2.3</jakarta.persistence-api.version>
 		<hibernate.version>5.6.4.Final</hibernate.version>
 		<jackson-datatype.version>2.13.2</jackson-datatype.version>


### PR DESCRIPTION
- Update Coherence from `21.12.2` to `21.12.3`
- Update log4j from `2.17.1` to `2.17.2`
- Update Spring Framework from `5.3.18` to `5.3.19`
- Update Spring Data from `2021.1.1` to `2021.1.4`

resolves #96 