### PR TITLE
Fix: CoherenceCache.get() with value loader does not check if entry is locked

### DIFF
--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/CoherenceAutoConfiguration.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/CoherenceAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -65,6 +65,10 @@ public class CoherenceAutoConfiguration {
 			coherenceCacheConfiguration.setCacheNamePrefix(cacheProperties.getCacheNamePrefix());
 			coherenceCacheConfiguration.setUseCacheNamePrefix(cacheProperties.isUseCacheNamePrefix());
 			coherenceCacheConfiguration.setTimeToLive(cacheProperties.getTimeToLive());
+			coherenceCacheConfiguration.setLockEntireCache(cacheProperties.isLockEntireCache());
+			coherenceCacheConfiguration.setLockTimeout(cacheProperties.getLockTimeout());
+			coherenceCacheConfiguration.setUseLocks(cacheProperties.isUseLocks());
+
 			return new CoherenceCacheManager(coherence, coherenceCacheConfiguration);
 		}
 		else {

--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/CoherenceProperties.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/CoherenceProperties.java
@@ -353,6 +353,23 @@ public class CoherenceProperties {
 		 */
 		private String cacheNamePrefix = "";
 
+		/**
+		 * Enabled by default. Lock cache entries. When using Coherence*Extend or gRPC, it is recommended to not use
+		 * locking.
+		 */
+		private boolean useLocks = true;
+
+		/**
+		 * Disabled by default. Locks the entire cache. This is usually not recommended.
+		 */
+		private boolean lockEntireCache = false;
+
+		/**
+		 * The number of milliseconds to continue trying to obtain a lock. When pass zero the lock attempt will to return
+		 * immediately. Passing -1 will block indefinitely until the lock could be obtained. Defaults to 0.
+		 */
+		private long lockTimeout = 0;
+
 		public Duration getTimeToLive() {
 			return this.timeToLive;
 		}
@@ -375,6 +392,30 @@ public class CoherenceProperties {
 
 		public void setUseCacheNamePrefix(boolean useCacheNamePrefix) {
 			this.useCacheNamePrefix = useCacheNamePrefix;
+		}
+
+		public boolean isUseLocks() {
+			return useLocks;
+		}
+
+		public void setUseLocks(boolean useLocks) {
+			this.useLocks = useLocks;
+		}
+
+		public boolean isLockEntireCache() {
+			return lockEntireCache;
+		}
+
+		public void setLockEntireCache(boolean lockEntireCache) {
+			this.lockEntireCache = lockEntireCache;
+		}
+
+		public long getLockTimeout() {
+			return lockTimeout;
+		}
+
+		public void setLockTimeout(long lockTimeout) {
+			this.lockTimeout = lockTimeout;
 		}
 	}
 

--- a/coherence-spring-boot-starter/src/test/java/com/oracle/coherence/spring/boot/tests/CoherencePropertiesTests.java
+++ b/coherence-spring-boot-starter/src/test/java/com/oracle/coherence/spring/boot/tests/CoherencePropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -122,6 +122,10 @@ public class CoherencePropertiesTests {
 		assertThat(this.coherenceProperties.getCache().getCacheNamePrefix()).isEqualTo("");
 		assertThat(this.coherenceProperties.getCache().getTimeToLive()).isEqualTo(Duration.ZERO);
 		assertThat(this.coherenceProperties.getCache().isUseCacheNamePrefix()).isFalse();
+
+		assertThat(this.coherenceProperties.getCache().getLockTimeout()).isEqualTo(0L);
+		assertThat(this.coherenceProperties.getCache().isLockEntireCache()).isFalse();
+		assertThat(this.coherenceProperties.getCache().isUseLocks()).isTrue();
 	}
 
 	private void validateConfigUri(String expectedConfigUri, SessionConfiguration sessionConfiguration) {

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cache/CoherenceCacheConfiguration.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/cache/CoherenceCacheConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -26,7 +26,24 @@ public class CoherenceCacheConfiguration {
 	private boolean useCacheNamePrefix = false;
 
 	/**
-	 * The String to prepend cache names with. Empty by default
+	 * Enabled by default. Lock cache entries. When using Coherence*Extend or gRPC, it is recommended to not use
+	 * locking.
+	 */
+	private boolean useLocks = true;
+
+	/**
+	 * Disabled by default. Locks the entire cache. This is usually not recommended.
+	 */
+	private boolean lockEntireCache = false;
+
+	/**
+	 * The number of milliseconds to continue trying to obtain a lock. When pass zero the lock attempt will to return
+	 * immediately. Passing -1 will block indefinitely until the lock could be obtained. Defaults to 0.
+	 */
+	private long lockTimeout = 0;
+
+	/**
+	 * The String to prepend cache names with. Empty by default.
 	 */
 	private String cacheNamePrefix = "";
 
@@ -79,5 +96,29 @@ public class CoherenceCacheConfiguration {
 		else {
 			return name;
 		}
+	}
+
+	public boolean isUseLocks() {
+		return this.useLocks;
+	}
+
+	public void setUseLocks(boolean useLocks) {
+		this.useLocks = useLocks;
+	}
+
+	public boolean isLockEntireCache() {
+		return this.lockEntireCache;
+	}
+
+	public void setLockEntireCache(boolean lockEntireCache) {
+		this.lockEntireCache = lockEntireCache;
+	}
+
+	public long getLockTimeout() {
+		return this.lockTimeout;
+	}
+
+	public void setLockTimeout(long lockTimeout) {
+		this.lockTimeout = lockTimeout;
 	}
 }

--- a/coherence-spring-docs/src/main/asciidoc/spring-cache.adoc
+++ b/coherence-spring-docs/src/main/asciidoc/spring-cache.adoc
@@ -139,3 +139,33 @@ for the samples is part of the Coherence Spring projects:
 
 If you're using Spring Boot, please continue reading the <<spring-boot.adoc#spring-boot-caching, Spring Boot specific chapter>>
 on caching.
+
+[[spring-cache-locking]]
+== Coherence Caches and Locking
+
+Oracle Coherence supports the explicit concurrency control of cache entries using locks. The configuration class
+`CoherenceCacheConfiguration` provides 3 options to specify the relevant settings:
+
+*useLocks*
+
+First you can specify whether you want to use looks or not. This options defaults to `true`, meaning that locking is
+enabled by default.
+
+IMPORTANT: When using caching via _Coherence*Extend_ or _gRPC_, please disable locking! Locking via Coherence*Extend or
+gRPC is not supported.
+
+*lockTimeout*
+
+When locking cache entries, you can set a cache timeout. The specified value in milliseconds, instructs Coherence how
+long it shall try to acquire a lock the cache entry. If a timeout occurs, Coherence Spring will throw an exception.
+A value of `-1` will cause Coherence to block indefintely. Specifying `0` will cause Oracle Coherence not to wait at all.
+By default, the value is set to `0`.
+
+*lockEntireCache*
+
+While generally not recommended, the option exists to also lock they entire cache (not just the specific cache entry).
+This option defaults to `false`.
+
+For further information, please read the corresponding chapter
+link:{oracle-coherence-docs}develop-applications/performing-transactions.html#GUID-4EAD6E6F-D074-4171-85AE-6F8198DDE33C[Using Explicit Locking for Data Concurrency]
+in the Oracle Coherence reference guide.


### PR DESCRIPTION
- Fix lock-check
- Add `lockTimeout` to `CoherenceCacheConfiguration`
- Add `useLocks` to `CoherenceCacheConfiguration`
- Add `lockEntireCache` to `CoherenceCacheConfiguration`
- Throw `ValueRetrievalException` instead of `IllegalStateException`

Resolves #89