### PR TITLE
Migrate to new AutoConfiguration support in Boot 2.7

### DIFF
--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/CoherenceAutoConfiguration.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/CoherenceAutoConfiguration.java
@@ -25,6 +25,7 @@ import com.tangosol.net.Coherence;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,7 +34,6 @@ import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
@@ -46,7 +46,7 @@ import org.springframework.util.CollectionUtils;
  * @author Gunnar Hillert
  * @since 3.0
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnMissingBean(CoherenceServer.class)
 @EnableCoherence
 @EnableConfigurationProperties({
@@ -122,7 +122,7 @@ public class CoherenceAutoConfiguration {
 		};
 	}
 
-	@Configuration(proxyBeanMethods = false)
+	@AutoConfiguration
 	@ConditionalOnMissingBean(CoherencePublisherProxyFactoryBean.class)
 	@Import(CoherencePublisherAutoConfigurationScanRegistrar.class)
 	public static class CoherencePublisherScanRegistrarConfiguration {

--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/data/CoherenceRepositoriesAutoConfiguration.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/data/CoherenceRepositoriesAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022 Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -10,10 +10,10 @@ import com.oracle.coherence.spring.data.repository.CoherenceRepository;
 import com.oracle.coherence.spring.data.support.CoherenceRepositoryConfigurationExtension;
 import com.oracle.coherence.spring.data.support.CoherenceRepositoryFactoryBean;
 
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Import;
  * @author Gunnar Hillert
  * @since 3.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass(CoherenceRepository.class)
 @ConditionalOnMissingBean({ CoherenceRepositoryFactoryBean.class, CoherenceRepositoryConfigurationExtension.class })
 @ConditionalOnProperty(prefix = "coherence.spring.data.repositories", name = "enabled", havingValue = "true",

--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/metrics/CoherenceMetricsAutoConfiguration.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/metrics/CoherenceMetricsAutoConfiguration.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
 package com.oracle.coherence.spring.boot.autoconfigure.metrics;
 
 
@@ -7,20 +13,21 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for {@link CoherenceMicrometerMetrics}.
  *
  * @author Vaso Putica
+ * @author Gunnar Hillert
  * @since 3.0
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnMissingBean(CoherenceMicrometerMetrics.class)
 @AutoConfigureAfter({CompositeMeterRegistryAutoConfiguration.class, MetricsAutoConfiguration.class})
 @ConditionalOnClass({CoherenceMicrometerMetrics.class, MeterRegistry.class})

--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/session/CoherenceSpringSessionAutoConfiguration.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/session/CoherenceSpringSessionAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -13,6 +13,7 @@ import com.oracle.coherence.spring.session.CoherenceIndexedSessionRepository;
 import com.oracle.coherence.spring.session.config.annotation.web.http.CoherenceHttpSessionConfiguration;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -22,7 +23,6 @@ import org.springframework.boot.autoconfigure.session.SessionProperties;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.session.SessionRepository;
 
 /**
@@ -32,7 +32,7 @@ import org.springframework.session.SessionRepository;
  * @since 3.0
  */
 @AutoConfigureAfter(CoherenceAutoConfiguration.class)
-@Configuration
+@AutoConfiguration
 @EnableConfigurationProperties(CoherenceSpringSessionProperties.class)
 @Conditional(CoherenceSpringSessionCondition.class)
 @ConditionalOnClass(CoherenceIndexedSessionRepository.class)
@@ -40,7 +40,7 @@ import org.springframework.session.SessionRepository;
 @ConditionalOnProperty(name = "coherence.spring.session.enabled", havingValue = "true", matchIfMissing = true)
 public class CoherenceSpringSessionAutoConfiguration {
 
-	@Configuration(proxyBeanMethods = false)
+	@AutoConfiguration
 	@AutoConfigureBefore(name = "org.springframework.boot.actuate.autoconfigure.session.SessionsEndpointAutoConfiguration")
 	public static class SpringBootCoherenceHttpSessionConfiguration extends CoherenceHttpSessionConfiguration {
 

--- a/coherence-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/coherence-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,13 +1,7 @@
-# Auto Configure
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.oracle.coherence.spring.boot.autoconfigure.CoherenceAutoConfiguration,\
-com.oracle.coherence.spring.boot.autoconfigure.session.CoherenceSpringSessionAutoConfiguration,\
-com.oracle.coherence.spring.boot.autoconfigure.metrics.CoherenceMetricsAutoConfiguration,\
-com.oracle.coherence.spring.boot.autoconfigure.data.CoherenceRepositoriesAutoConfiguration
-
 # ConfigData Resolver
 org.springframework.boot.context.config.ConfigDataLocationResolver=\
 com.oracle.coherence.spring.boot.config.CoherenceConfigDataLocationResolver
+
 # ConfigData Loader
 org.springframework.boot.context.config.ConfigDataLoader=\
 com.oracle.coherence.spring.boot.config.CoherenceConfigDataLoader

--- a/coherence-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/coherence-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,4 @@
+com.oracle.coherence.spring.boot.autoconfigure.CoherenceAutoConfiguration
+com.oracle.coherence.spring.boot.autoconfigure.session.CoherenceSpringSessionAutoConfiguration
+com.oracle.coherence.spring.boot.autoconfigure.metrics.CoherenceMetricsAutoConfiguration
+com.oracle.coherence.spring.boot.autoconfigure.data.CoherenceRepositoriesAutoConfiguration

--- a/coherence-spring-boot-starter/src/test/java/com/oracle/coherence/spring/boot/tests/CoherenceSpringFactoryTests.java
+++ b/coherence-spring-boot-starter/src/test/java/com/oracle/coherence/spring/boot/tests/CoherenceSpringFactoryTests.java
@@ -7,13 +7,20 @@
 package com.oracle.coherence.spring.boot.tests;
 
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import com.oracle.coherence.spring.boot.autoconfigure.CoherenceAutoConfiguration;
+import com.oracle.coherence.spring.boot.autoconfigure.data.CoherenceRepositoriesAutoConfiguration;
+import com.oracle.coherence.spring.boot.autoconfigure.metrics.CoherenceMetricsAutoConfiguration;
+import com.oracle.coherence.spring.boot.autoconfigure.session.CoherenceSpringSessionAutoConfiguration;
 import com.oracle.coherence.spring.boot.config.CoherenceConfigDataLoader;
 import com.oracle.coherence.spring.boot.config.CoherenceConfigDataLocationResolver;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.context.annotation.ImportCandidates;
 import org.springframework.boot.context.config.ConfigDataLoader;
 import org.springframework.boot.context.config.ConfigDataLocationResolver;
 import org.springframework.core.io.support.SpringFactoriesLoader;
@@ -26,9 +33,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CoherenceSpringFactoryTests {
 
 	@Test
-	void testPresenceOfAutoConfigurationClass() {
-		final List<String> autoConfigurationClasses = SpringFactoriesLoader.loadFactoryNames(EnableAutoConfiguration.class, getClass().getClassLoader());
-		assertThat(autoConfigurationClasses).contains(CoherenceAutoConfiguration.class.getName());
+	void testPresenceOfCoherenceAutoConfigurationClasses() {
+		final ImportCandidates importCandidates = ImportCandidates.load(AutoConfiguration.class, this.getClass().getClassLoader());
+
+		final Predicate<String> p1 = (importCandidate) -> importCandidate.equals(CoherenceAutoConfiguration.class.getName());
+		final Predicate<String> p2 = (importCandidate) -> importCandidate.equals(CoherenceSpringSessionAutoConfiguration.class.getName());
+		final Predicate<String> p3 = (importCandidate) -> importCandidate.equals(CoherenceMetricsAutoConfiguration.class.getName());
+		final Predicate<String> p4 = (importCandidate) -> importCandidate.equals(CoherenceRepositoriesAutoConfiguration.class.getName());
+
+		final List<String> coherenceImportCandidates = StreamSupport.stream(importCandidates.spliterator(), false)
+				.filter(p1.or(p2).or(p3).or(p4))
+				.limit(4).collect(Collectors.toList());
+		assertThat(coherenceImportCandidates.size()).isEqualTo(4);
+		assertThat(coherenceImportCandidates).containsExactly(
+				"com.oracle.coherence.spring.boot.autoconfigure.CoherenceAutoConfiguration",
+				"com.oracle.coherence.spring.boot.autoconfigure.session.CoherenceSpringSessionAutoConfiguration",
+				"com.oracle.coherence.spring.boot.autoconfigure.metrics.CoherenceMetricsAutoConfiguration",
+				"com.oracle.coherence.spring.boot.autoconfigure.data.CoherenceRepositoriesAutoConfiguration"
+		);
 	}
 
 	@Test


### PR DESCRIPTION
- add org.springframework.boot.autoconfigure.AutoConfiguration.imports file
- use @AutoConfiguration annotation (since Spring Boot 2.7)