### PR TITLE
gh-137 Refactor gRPC Configuration Support

### DIFF
--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/CoherenceProperties.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/CoherenceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -276,12 +276,18 @@ public class CoherenceProperties {
 	public static class SessionProperties {
 
 		/**
-		 * Session configuration.
+		 * gRPC Session configuration.
+		 * @deprecated As of 4.0 please use the {@code client} property and configure the relevant gRPC configuration
+		 * properties directly via {@code coherence-cache-config.xml}.
 		 */
+		@Deprecated(
+				since = "4.0.0",
+				forRemoval = true
+		)
 		private List<GrpcSessionConfigurationBean> grpc;
 
 		/**
-		 * Session configuration.
+		 * Client Session configuration.
 		 */
 		private List<ClientSessionConfigurationBean> client;
 
@@ -290,10 +296,18 @@ public class CoherenceProperties {
 		 */
 		private List<ServerSessionConfigurationBean> server;
 
+		@Deprecated(
+				since = "4.0.0",
+				forRemoval = true
+		)
 		public List<GrpcSessionConfigurationBean> getGrpc() {
 			return this.grpc;
 		}
 
+		@Deprecated(
+				since = "4.0.0",
+				forRemoval = true
+		)
 		public void setGrpc(List<GrpcSessionConfigurationBean> grpc) {
 			this.grpc = grpc;
 		}

--- a/coherence-spring-core/pom.xml
+++ b/coherence-spring-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2013, 2022, Oracle and/or its affiliates.
+  Copyright (c) 2013, 2023, Oracle and/or its affiliates.
   Licensed under the Universal Permissive License v 1.0 as shown at
   https://oss.oracle.com/licenses/upl.
 -->
@@ -118,7 +118,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
 			<version>${log4j.version}</version>
 			<scope>test</scope>
 		</dependency>
@@ -156,6 +156,12 @@
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 			<version>${awaitility.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.oracle.coherence.ce</groupId>
+			<artifactId>coherence-bedrock-testing-support</artifactId>
+			<version>${coherence.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/session/ClientSessionConfigurationBean.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/session/ClientSessionConfigurationBean.java
@@ -1,5 +1,37 @@
+/*
+ * Copyright 2021-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.oracle.coherence.spring.configuration.session;
 
+/**
+ * Creates an instance of {@link com.tangosol.net.SessionConfiguration} that will be
+ * created for each named session in the application configuration properties.
+ * <p>
+ * Instances of {@link com.tangosol.net.SessionConfiguration} are used for both Coherence*Extend configurations and
+ * (since 4.0) for Grpc configurations.
+ * <p>
+ * Sessions are configured with the {@code coherence.session} prefix,
+ * for example {@code coherence.session.foo} configures a session named
+ * foo.
+ * <p>
+ * The session name {@code default} is a special case that configures
+ * the default session named {@link com.tangosol.net.Coherence#DEFAULT_NAME}.
+ * @author Gunnar Hillert
+ * @since 3.0
+ * @see com.tangosol.net.SessionConfiguration
+ */
 public class ClientSessionConfigurationBean extends SessionConfigurationBean {
 	public ClientSessionConfigurationBean() {
 		super.setType(SessionType.CLIENT);

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/session/GrpcSessionConfigurationBean.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/session/GrpcSessionConfigurationBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -33,9 +33,14 @@ import org.springframework.context.ConfigurableApplicationContext;
  * the default session named {@link com.tangosol.net.Coherence#DEFAULT_NAME}.
  * @author Gunnar Hillert
  * @since 3.0
- *
  * @see GrpcSessionConfiguration
+ * @see ClientSessionConfigurationBean
+ * @deprecated As of 4.0 please configure the Grpc Client using the coherence-cache-config.xml
  */
+@Deprecated(
+		since = "4.0.0",
+		forRemoval = true
+)
 public class GrpcSessionConfigurationBean extends AbstractSessionConfigurationBean {
 
 	/**
@@ -75,14 +80,13 @@ public class GrpcSessionConfigurationBean extends AbstractSessionConfigurationBe
 
 	@Override
 	public Optional<SessionConfiguration> getConfiguration() {
-		if (this.getType() != SessionType.GRPC) {   //TODO
+		if (this.getType() != SessionType.GRPC) {
 			return Optional.empty();
 		}
 
 		GrpcSessionConfiguration.Builder builder;
 
 		if (this.channelName == null || this.channelName.trim().isEmpty()) {
-			//TODO builder = GrpcSessionConfiguration.builder(GrpcSessionConfiguration.DEFAULT_HOST);
 			builder = GrpcSessionConfiguration.builder();
 		}
 		else {

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/session/SessionType.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/session/SessionType.java
@@ -31,7 +31,12 @@ public enum SessionType {
 
 	/**
 	 * The session is a gRPC client session.
+	 * @deprecated use {@link SessionType#CLIENT} instead
 	 */
+	@Deprecated(
+			since = "4.0.0",
+			forRemoval = true
+	)
 	GRPC,
 
 	/**

--- a/coherence-spring-core/src/test/resources/grpc-test-coherence-cache-config.xml
+++ b/coherence-spring-core/src/test/resources/grpc-test-coherence-cache-config.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2023, Oracle and/or its affiliates.
+  Licensed under the Universal Permissive License v 1.0 as shown at
+  https://oss.oracle.com/licenses/upl.
+-->
+
+<cache-config
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"
+	xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-cache-config coherence-cache-config.xsd">
+	<caching-scheme-mapping>
+		<cache-mapping>
+			<cache-name>fooMap</cache-name>
+			<scheme-name>remote-grpc</scheme-name>
+		</cache-mapping>
+	</caching-scheme-mapping>
+
+	<caching-schemes>
+		<remote-grpc-cache-scheme>
+			<scheme-name>remote-grpc</scheme-name>
+			<service-name>RemoteGrpcCache</service-name>
+			<cluster-name>GrpcSessionTestsCluster</cluster-name>
+		</remote-grpc-cache-scheme>
+	</caching-schemes>
+
+</cache-config>

--- a/coherence-spring-docs/src/main/asciidoc/core.adoc
+++ b/coherence-spring-docs/src/main/asciidoc/core.adoc
@@ -98,17 +98,20 @@ import the `CoherenceSpringConfiguration` class under the covers. Therefore, you
 
 In most use-cases, only a single Coherence Session is expected to be used. Therefore, without providing any further
 configuration the default session is configured using the embedded default configuration file. This results in the application
-joining Coherence as a cluster member (Session type `SERVER`). This is of course not the only way. Coherence Spring support
+joining Coherence as a _cluster_ member (Session type `SERVER`). This is of course not the only way. Coherence Spring support
 the following 3 session types:
 
 - *SERVER* - Join as Coherence cluster member. This is the default session type.
-- *CLIENT* - Connect to Coherence as a Coherence*Extend client
-- *GRPC* - Connect to Coherence as gRPC client
+- *CLIENT* - Connect to Coherence as a Coherence*Extend or gRPC client
+- *GRPC* - Connect to Coherence as gRPC client (deprecated, use *CLIENT* instead)
 
-If the application is a Coherence cluster member, or a Coherence*Extend client, then all that needs to be specified is
-the Coherence configuration file name. For instance, you may for example provide an implementation of
-the `AbstractSessionConfigurationBean`, to specify the type of your session and to use a custom Coherence configuration
-file.
+IMPORTANT: As of Coherence Spring `4.0`, the `GRPC` session type has been deprecated. Please use `CLIENT` instead.
+Since Coherence `22.06.2`, relevant gRPC configuration can be configured directly in the `coherence-cache-config.xml`
+file as described in the Coherence reference guide chapter
+{oracle-coherence-docs}develop-remote-clients/using-coherence-java-grpc-client.html#GUID-76F8E59F-3933-45CD-8C21-C13072D4D46D[Configuring the Coherence gRPC Client].
+
+In order to configure the type of your Session, you may declare a `SessionConfigurationBean` that allows to you to not only
+to set the session type but also to specify a custom Coherence configuration file or a custom session name.
 
 .SessionConfigurationBean
 [source,java,indent=1,subs="verbatim,quotes,attributes"]
@@ -123,22 +126,8 @@ SessionConfigurationBean sessionConfigurationBeanDefault() {
 }
 ----
 
-If you connect as gRPC client, however, the properties change slightly and you need to specify a
-`GrpcSessionConfigurationBean`:
-
-.GrpcSessionConfigurationBean
-[source,java,indent=1,subs="verbatim,quotes,attributes"]
-----
-@Bean
-GrpcSessionConfigurationBean grpcSessionConfigurationBean() {
-    final GrpcSessionConfigurationBean sessionConfigurationBean = new GrpcSessionConfigurationBean();
-    sessionConfigurationBean.setName("sessionName");
-    sessionConfigurationBean.setChannelName("grpcChanelBeanName");
-    return sessionConfigurationBean;
-}
-----
-
-The Channel Name property would refer to a grpcChannel bean.
+NOTE: The option of declaring a `GrpcSessionConfigurationBean` for gRPC clients has been deprecated. Please use session
+type `CLIENT` instead and configure the gRPC relevant configuration properties in your `coherence-cache-config.xml` file.
 
 [[coherence-spring-botstrap-with-multiple-session]]
 == Configure Multiple Sessions
@@ -172,9 +161,14 @@ The session type of this configuration. There are three different types of sessi
 
 - *server* represents storage enabled cluster member session.
 - *client* represents a storage disabled cluster member or Coherence*Extend client session.
-- *grpc* is a gRPC client session (see the gRPC documentation).
+- *grpc* (deprecated) is a gRPC client session (see the gRPC documentation).
 
 The type of the session affects how the bootstrap API starts the session.
+
+IMPORTANT: As of Coherence Spring `4.0`, the `GRPC` session type has been deprecated. Please use `CLIENT` instead.
+Since Coherence `22.06.2`, relevant gRPC configuration can be configured directly in the `coherence-cache-config.xml`
+file as described in the Coherence reference guide chapter
+{oracle-coherence-docs}develop-remote-clients/using-coherence-java-grpc-client.html#GUID-76F8E59F-3933-45CD-8C21-C13072D4D46D[Configuring the Coherence gRPC Client].
 
 **priority**
 
@@ -188,21 +182,23 @@ The following property applies to the `CLIENT` (Coherence*Extend) and `Server` m
 The Coherence cache configuration URI for the session. As already mentioned, the most common configuration to set will
 be the Coherence configuration file name. If not specified, the default value will be `coherence-cache-config.xml`.
 
-The following property applies to the `GRPC` mode, only:
+The following property applies to the deprecated `GRPC` mode, only:
 
-**channelName**
+**channelName** (deprecated)
 
-Sets the underlying gRPC channel. If not set, it will default to `localhost` and port `1408`.
+Sets the underlying gRPC channel. If not set, it will default to `localhost` and port `1408`. This property is
+deprecated. See note under **type**.
 
-**serializer**
+**serializer** (deprecated)
 
 Specifies the serializer to that shall be used, in order to serialize gRPC message payloads. If not specified,
 the serializer will be the default Coherence serializer, either POF if it has been enabled with the `coherence.pof.enabled`
-system property or Java serialization.
+system property or Java serialization. This property is deprecated. See note under **type**.
 
-**tracingEnabled**
+**tracingEnabled** (deprecated)
 
-Specifies if client gRPC tracing should be enabled. This is `false` by default.
+Specifies if client gRPC tracing should be enabled. This is `false` by default. This property is
+deprecated. See note under **type**.
 
 [[coherence-spring-dependency-injection]]
 == Dependency Injection

--- a/coherence-spring-docs/src/main/asciidoc/spring-boot.adoc
+++ b/coherence-spring-docs/src/main/asciidoc/spring-boot.adoc
@@ -99,7 +99,7 @@ No messages are emitted if `-1` is specified. More log messages are emitted as t
 
 | coherence.sessions.<type>
 | N/A
-| Indicates the type of the session. One of the following: `grpc`, `server`, `client`
+| Indicates the type of the session. One of the following: `grpc` (deprecated), `server`, `client`
 
 | coherence.sessions.<type>[0].name
 |
@@ -131,11 +131,16 @@ No messages are emitted if `-1` is specified. More log messages are emitted as t
 
 - {coherence-spring-api}com/oracle/coherence/spring/configuration/session/AbstractSessionConfigurationBean.html[AbstractSessionConfigurationBean]
 - {coherence-spring-api}com/oracle/coherence/spring/configuration/session/SessionConfigurationBean.html[SessionConfigurationBean]
-- {coherence-spring-api}com/oracle/coherence/spring/configuration/session/GrpcSessionConfigurationBean.html[GrpcSessionConfigurationBean]
+- {coherence-spring-api}com/oracle/coherence/spring/configuration/session/GrpcSessionConfigurationBean.html[GrpcSessionConfigurationBean] (deprecated)
 
 IMPORTANT: Many properties are translated into native Coherence properties. If both
 Spring Boot property AND a native property `coherence.properties.*` are configured, the Spring Boot
 property is used.
+
+IMPORTANT: As of Coherence Spring `4.0`, the `GrpcSessionConfigurationBean` has been deprecated. Please use the
+`SessionConfigurationBean` in that case. Since Coherence `22.06.2`, relevant gRPC configuration can be configured directly in
+the `coherence-cache-config.xml` file as described in the Coherence reference guide chapter
+{oracle-coherence-docs}develop-remote-clients/using-coherence-java-grpc-client.html#GUID-76F8E59F-3933-45CD-8C21-C13072D4D46D[Configuring the Coherence gRPC Client].
 
 If the provided Spring Boot configuration properties are not sufficient for your needs, you can also specify any of
 the native Coherence properties. For a list of available native properties, please consult the reference guide chapter on

--- a/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/AbstractCoherenceIndexedSessionRepositoryTests.java
+++ b/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/AbstractCoherenceIndexedSessionRepositoryTests.java
@@ -1,14 +1,11 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
  */
 package com.oracle.coherence.spring.session;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.Socket;
 import java.util.Map;
 
 import com.tangosol.net.Coherence;
@@ -308,22 +305,4 @@ abstract class AbstractCoherenceIndexedSessionRepositoryTests {
 		this.repository.deleteById(session.getId());
 		assertThat(this.repository.findById(session.getId())).isNull();
 	}
-
-	/**
-	 * Helper method to determine if the default gRPC port is available or not.
-	 * @return true if the gRPC port is bound and thus unavailable
-	 */
-	protected static boolean isGrpcPortInUse() {
-
-		boolean result = false;
-
-		try {
-			(new Socket(InetAddress.getLoopbackAddress(), 1408)).close();
-			result = true;
-		}
-		catch (IOException ex) {
-		}
-		return result;
-	}
-
 }

--- a/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/GrpcSessionCoherenceIndexedSessionRepositoryTests.java
+++ b/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/GrpcSessionCoherenceIndexedSessionRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -19,6 +19,7 @@ import com.oracle.coherence.grpc.proxy.GrpcServerController;
 import com.oracle.coherence.spring.configuration.annotation.EnableCoherence;
 import com.oracle.coherence.spring.configuration.session.GrpcSessionConfigurationBean;
 import com.oracle.coherence.spring.session.config.annotation.web.http.EnableCoherenceHttpSession;
+import com.oracle.coherence.spring.test.utils.NetworkUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,7 +62,7 @@ public class GrpcSessionCoherenceIndexedSessionRepositoryTests extends AbstractC
 				SystemProperty.of("coherence.grpc.server.port", "1408"),
 				DisplayName.of("server"));
 
-		Awaitility.await().atMost(70, TimeUnit.SECONDS).until(() -> isGrpcPortInUse());
+		Awaitility.await().atMost(70, TimeUnit.SECONDS).until(() -> NetworkUtils.isGrpcPortInUse());
 	}
 
 	@AfterAll
@@ -70,7 +71,7 @@ public class GrpcSessionCoherenceIndexedSessionRepositoryTests extends AbstractC
 		if (server != null) {
 			server.close();
 		}
-		Awaitility.await().atMost(70, TimeUnit.SECONDS).until(() -> !isGrpcPortInUse());
+		Awaitility.await().atMost(70, TimeUnit.SECONDS).until(() -> !NetworkUtils.isGrpcPortInUse());
 	}
 
 	@Configuration

--- a/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/PofCoherenceIndexedSessionRepositoryTests.java
+++ b/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/PofCoherenceIndexedSessionRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -19,6 +19,7 @@ import com.oracle.coherence.grpc.proxy.GrpcServerController;
 import com.oracle.coherence.spring.configuration.annotation.EnableCoherence;
 import com.oracle.coherence.spring.configuration.session.GrpcSessionConfigurationBean;
 import com.oracle.coherence.spring.session.config.annotation.web.http.EnableCoherenceHttpSession;
+import com.oracle.coherence.spring.test.utils.NetworkUtils;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.awaitility.Awaitility;
@@ -60,7 +61,7 @@ class PofCoherenceIndexedSessionRepositoryTests extends AbstractCoherenceIndexed
 				IPv4Preferred.yes(),
 				DisplayName.of("server"));
 
-		Awaitility.await().atMost(70, TimeUnit.SECONDS).until(() -> isGrpcPortInUse());
+		Awaitility.await().atMost(70, TimeUnit.SECONDS).until(() -> NetworkUtils.isGrpcPortInUse());
 	}
 
 	@AfterAll
@@ -70,7 +71,7 @@ class PofCoherenceIndexedSessionRepositoryTests extends AbstractCoherenceIndexed
 		if (server != null) {
 			server.close();
 		}
-		Awaitility.await().atMost(70, TimeUnit.SECONDS).until(() -> !isGrpcPortInUse());
+		Awaitility.await().atMost(70, TimeUnit.SECONDS).until(() -> !NetworkUtils.isGrpcPortInUse());
 	}
 
 	@Configuration

--- a/coherence-spring-tests/src/main/java/com/oracle/coherence/spring/test/utils/NetworkUtils.java
+++ b/coherence-spring-tests/src/main/java/com/oracle/coherence/spring/test/utils/NetworkUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
+package com.oracle.coherence.spring.test.utils;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+public class NetworkUtils {
+
+	/**
+	 * Helper method to determine if the default gRPC port is available or not.
+	 * @return true if the gRPC port is bound and thus unavailable
+	 */
+	public static boolean isGrpcPortInUse() {
+
+		boolean result = false;
+
+		try {
+			(new Socket(InetAddress.getLoopbackAddress(), 1408)).close();
+			result = true;
+		}
+		catch (IOException ex) {
+		}
+		return result;
+	}
+}

--- a/coherence-spring-tests/src/main/java/com/oracle/coherence/spring/test/utils/package-info.java
+++ b/coherence-spring-tests/src/main/java/com/oracle/coherence/spring/test/utils/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains test-relevant utility classes.
+ */
+package com.oracle.coherence.spring.test.utils;


### PR DESCRIPTION
- Add deprecations
- Add GrpcSessionTests
- Use Bedrock for GrpcSessionBeanTests and GrpcSessionTests
- Update documentation

resolves #137 