### PR TITLE
gh-167 Coherence Spring Session - Add support for persisting sessions without EntryProcessor

### DIFF
--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/session/CoherenceSpringSessionAutoConfiguration.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/session/CoherenceSpringSessionAutoConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -55,7 +55,7 @@ public class CoherenceSpringSessionAutoConfiguration {
 			setSessionMapName(coherenceSpringSessionProperties.getMapName());
 			setFlushMode(coherenceSpringSessionProperties.getFlushMode());
 			setSaveMode(coherenceSpringSessionProperties.getSaveMode());
+			setUseEntryProcessor(coherenceSpringSessionProperties.getUseEntryProcessor());
 		}
-
 	}
 }

--- a/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/session/CoherenceSpringSessionProperties.java
+++ b/coherence-spring-boot-starter/src/main/java/com/oracle/coherence/spring/boot/autoconfigure/session/CoherenceSpringSessionProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -38,6 +38,11 @@ public class CoherenceSpringSessionProperties {
 	 */
 	private SaveMode saveMode = SaveMode.ON_SET_ATTRIBUTE;
 
+	/**
+	 * Shall a Coherence Entry Processor be used for handling updates to the persisted HTTP session? Defaults to true.
+	 */
+	private boolean useEntryProcessor = true;
+
 	public String getMapName() {
 		return this.mapName;
 	}
@@ -62,4 +67,11 @@ public class CoherenceSpringSessionProperties {
 		this.saveMode = saveMode;
 	}
 
+	public boolean getUseEntryProcessor() {
+		return this.useEntryProcessor;
+	}
+
+	public void setUseEntryProcessor(boolean useEntryProcessor) {
+		this.useEntryProcessor = useEntryProcessor;
+	}
 }

--- a/coherence-spring-boot-starter/src/test/java/com/oracle/coherence/spring/boot/tests/CoherenceSpringSessionAutoConfigurationTests.java
+++ b/coherence-spring-boot-starter/src/test/java/com/oracle/coherence/spring/boot/tests/CoherenceSpringSessionAutoConfigurationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -9,6 +9,7 @@ package com.oracle.coherence.spring.boot.tests;
 import com.oracle.coherence.spring.boot.autoconfigure.CoherenceAutoConfiguration;
 import com.oracle.coherence.spring.boot.autoconfigure.CoherenceProperties;
 import com.oracle.coherence.spring.boot.autoconfigure.session.CoherenceSpringSessionAutoConfiguration;
+import com.oracle.coherence.spring.session.CoherenceIndexedSessionRepository;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -53,4 +54,36 @@ public class CoherenceSpringSessionAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasSingleBean(SessionRepository.class));
 	}
 
+	@Test
+	void testAutoConfigurationWithUseEntryProcessorTrue() {
+		this.contextRunner.withPropertyValues("coherence.spring.session.use-entry-processor=true")
+				.run((context) -> {
+					assertThat(context).hasSingleBean(SessionRepository.class);
+					final CoherenceIndexedSessionRepository sessionRepository =
+							context.getBean(CoherenceIndexedSessionRepository.class);
+					assertThat(sessionRepository.isUseEntryProcessor()).isTrue();
+				});
+	}
+
+	@Test
+	void testAutoConfigurationWithUseEntryProcessorTrueButNotSet() {
+		this.contextRunner.withPropertyValues("coherence.spring.session.enabled=true")
+				.run((context) -> {
+					assertThat(context).hasSingleBean(SessionRepository.class);
+					final CoherenceIndexedSessionRepository sessionRepository =
+							context.getBean(CoherenceIndexedSessionRepository.class);
+					assertThat(sessionRepository.isUseEntryProcessor()).isTrue();
+				});
+	}
+
+	@Test
+	void testAutoConfigurationWithUseEntryProcessorFalse() {
+		this.contextRunner.withPropertyValues("coherence.spring.session.use-entry-processor=false")
+				.run((context) -> {
+					assertThat(context).hasSingleBean(SessionRepository.class);
+					final CoherenceIndexedSessionRepository sessionRepository =
+							context.getBean(CoherenceIndexedSessionRepository.class);
+					assertThat(sessionRepository.isUseEntryProcessor()).isFalse();
+				});
+	}
 }

--- a/coherence-spring-docs/src/main/asciidoc/spring-boot.adoc
+++ b/coherence-spring-docs/src/main/asciidoc/spring-boot.adoc
@@ -713,6 +713,10 @@ The following Coherence-specific configuration properties are available:
 | `ON_SET_ATTRIBUTE`
 | The session save mode determines how session changes are tracked and saved to the session store.
 
+| coherence.spring.session.use-entry-processor
+| `true`
+| If true, a Coherence Entry Processor will be used for handling updates to the persisted HTTP session.
+
 |===
 
 [[spring-boot-messaging]]

--- a/coherence-spring-docs/src/main/asciidoc/spring-session.adoc
+++ b/coherence-spring-docs/src/main/asciidoc/spring-session.adoc
@@ -58,7 +58,8 @@ Session using the `@EnableCoherenceHttpSession` annotation.
         session = "coherence_session",           // <2>
         cache = "spring:session:sessions",       // <3>
         flushMode = FlushMode.ON_SAVE,           // <4>
-        sessionTimeoutInSeconds = 1800           // <5>
+        sessionTimeoutInSeconds = 1800,          // <5>
+        useEntryProcessor = true                 // <6>
 )
 static class CoherenceSessionConfig {
 }
@@ -68,11 +69,16 @@ static class CoherenceSessionConfig {
 <3> The name of the cache to use. Optional. Defaults to `spring:session:sessions`.
 <4> The FlushMode to use. Optional. Defaults to `FlushMode.ON_SAVE`.
 <5> The session timeout. Optional. Defaults to `1800` seconds (`30` minutes)
+<6> When doing HTTP session updates, shall we use a Coherence entry processor? The default is {@code true}.
 
 Are you running Coherence as a dedicated server instance? Then you need to make sure that your Coherence
 server may need one or more additional dependencies on its classpath for serialization. Depending on your requirements,
 you may need `Coherence Spring Session`, `Spring Security Core`, `Spring Security Web`. Please also ensure that dependency
 version between Coherence server and application clients matches exactly.
+
+An alternative is to set `useEntryProcessor` to `false`. This is less efficient as the entire session has to be sent over
+the wire when updating session properties. The positive side effect is that your Coherence server instance will not need
+to be aware of the additional dependencies on its classpath.
 
 [[spring-session-pof]]
 == POF Serialization
@@ -149,6 +155,9 @@ $ java -jar samples/spring-session-demo/spring-session-demo-app/target/spring-se
 [[spring-session-sample-start-remote-coherence]]
 === Spring Session with Remote Coherence Instances
 
+In this variation of the examle, we will start 1 central Coherence Server and the application will access that remote
+Coherence instance as a Coherence*Extend client.
+
 .Build the Coherence Server instance
 [source,shell,indent=1,subs="verbatim,quotes,attributes"]
 ----
@@ -166,9 +175,22 @@ Now we are ready to run the application. We will activate the `coherence-client`
 .Run the Spring Boot application
 [source,shell,indent=1,subs="verbatim,quotes,attributes"]
 ----
-$ java -jar samples/spring-session-demo/spring-session-demo-app/target/spring-session-demo-server-{coherence-spring-version}.jar
-$ java -jar samples/spring-session-demo/spring-session-demo-app/target/spring-session-demo-app-{coherence-spring-version}.jar
+$ java -jar samples/spring-session-demo/spring-session-demo-server/target/spring-session-demo-server-{coherence-spring-version}.jar
+$ java -jar samples/spring-session-demo/spring-session-demo-app/target/spring-session-demo-app-{coherence-spring-version}.jar --spring.profiles.active=coherence-client
 ----
+
+By default, Coherence Spring Session uses a Coherence Entry Processor to perform updates to the persisted HTTP Session. This
+will prevent the entire session to be sent over the wire. A drawback of that approach is that the Coherence instance needs
+to be aware of Coherence Spring classes for serialization purposes.
+
+Alternatively, you can also set the Coherence Spring Session property `coherence.spring.session.use-entry-processor` and
+set it to `false` (It is `true` by default) in the client application `spring-session-demo-app`. With that in place, you
+can now remove the relevant Maven dependencies:
+
+- spring-security-web
+- coherence-spring-session
+
+from the server application module `spring-session-demo-server` and the application will still work.
 
 [[spring-session-sample-rest-endpoints]]
 === Accessing the REST Endpoints

--- a/coherence-spring-session/src/main/java/com/oracle/coherence/spring/session/config/annotation/web/http/CoherenceHttpSessionConfiguration.java
+++ b/coherence-spring-session/src/main/java/com/oracle/coherence/spring/session/config/annotation/web/http/CoherenceHttpSessionConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -60,6 +60,8 @@ public class CoherenceHttpSessionConfiguration extends SpringHttpSessionConfigur
 	private FlushMode flushMode = FlushMode.ON_SAVE;
 	private SaveMode saveMode = SaveMode.ON_SET_ATTRIBUTE;
 
+	private boolean useEntryProcessor = true;
+
 	private Coherence coherence;
 
 	private IndexResolver<Session> indexResolver;
@@ -104,6 +106,7 @@ public class CoherenceHttpSessionConfiguration extends SpringHttpSessionConfigur
 		}
 		this.flushMode = attributes.getEnum("flushMode");
 		this.saveMode = attributes.getEnum("saveMode");
+		this.useEntryProcessor = attributes.getBoolean("useEntryProcessor");
 	}
 
 	@Autowired(required = false)
@@ -133,6 +136,10 @@ public class CoherenceHttpSessionConfiguration extends SpringHttpSessionConfigur
 		this.saveMode = saveMode;
 	}
 
+	public void setUseEntryProcessor(boolean useEntryProcessor) {
+		this.useEntryProcessor = useEntryProcessor;
+	}
+
 	private CoherenceIndexedSessionRepository createCoherenceIndexedSessionRepository() {
 		if (logger.isInfoEnabled()) {
 			logger.info("Creating CoherenceIndexedSessionRepository...");
@@ -156,6 +163,7 @@ public class CoherenceHttpSessionConfiguration extends SpringHttpSessionConfigur
 		sessionRepository.setDefaultMaxInactiveInterval(Duration.ofSeconds(this.maxInactiveIntervalInSeconds));
 		sessionRepository.setFlushMode(this.flushMode);
 		sessionRepository.setSaveMode(this.saveMode);
+		sessionRepository.setUseEntryProcessor(this.useEntryProcessor);
 		this.sessionRepositoryCustomizers
 				.forEach((sessionRepositoryCustomizer) -> sessionRepositoryCustomizer.customize(sessionRepository));
 		return sessionRepository;

--- a/coherence-spring-session/src/main/java/com/oracle/coherence/spring/session/config/annotation/web/http/EnableCoherenceHttpSession.java
+++ b/coherence-spring-session/src/main/java/com/oracle/coherence/spring/session/config/annotation/web/http/EnableCoherenceHttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -77,4 +77,9 @@ public @interface EnableCoherenceHttpSession {
 	 */
 	SaveMode saveMode() default SaveMode.ON_SET_ATTRIBUTE;
 
+	/**
+	 * Specify whether an entry processor shall be used when updating the HTTP session. The default is {@code true}.
+	 * @return true if an entry processor is to be used
+	 */
+	boolean useEntryProcessor() default true;
 }

--- a/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/AbstractCoherenceIndexedSessionRepositoryTests.java
+++ b/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/AbstractCoherenceIndexedSessionRepositoryTests.java
@@ -42,6 +42,8 @@ abstract class AbstractCoherenceIndexedSessionRepositoryTests {
 
 	protected String expectedCacheName;
 
+	protected boolean expectedToUseEntryProcessor = true;
+
 	@Autowired
 	private Coherence coherenceInstance;
 
@@ -49,6 +51,11 @@ abstract class AbstractCoherenceIndexedSessionRepositoryTests {
 	private CoherenceIndexedSessionRepository repository;
 
 	protected String sessionName;
+
+	@Test
+	void verifyCoherenceIndexedSessionRepositoryProperties() {
+		assertThat(this.repository.isUseEntryProcessor()).isEqualTo(this.expectedToUseEntryProcessor);
+	}
 
 	@Test
 	void createAndDestroyCoherenceSession() {

--- a/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/CoherenceIndexedSessionRepositoryWithoutEntryProcessorTests.java
+++ b/coherence-spring-session/src/test/java/com/oracle/coherence/spring/session/CoherenceIndexedSessionRepositoryWithoutEntryProcessorTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
+package com.oracle.coherence.spring.session;
+
+import com.oracle.coherence.spring.configuration.annotation.EnableCoherence;
+import com.oracle.coherence.spring.session.config.annotation.web.http.EnableCoherenceHttpSession;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+
+/**
+ * Tests for {@link CoherenceIndexedSessionRepository} using embedded Coherence. For this test class
+ * {@code useEntryProcessor} is set to @{code false}.
+ *
+ * @author Gunnar Hillert
+ */
+@DirtiesContext
+@SpringJUnitWebConfig
+class CoherenceIndexedSessionRepositoryWithoutEntryProcessorTests extends AbstractCoherenceIndexedSessionRepositoryTests {
+
+	@BeforeEach
+	void setup() {
+		super.expectedToUseEntryProcessor = false;
+	}
+
+	@EnableCoherenceHttpSession(useEntryProcessor = false)
+	@EnableCoherence
+	@Configuration
+	static class CoherenceSessionConfig {
+	}
+
+}

--- a/samples/spring-session-demo/spring-session-demo-app/src/main/resources/application-coherence-client.yaml
+++ b/samples/spring-session-demo/spring-session-demo-app/src/main/resources/application-coherence-client.yaml
@@ -1,4 +1,10 @@
 coherence:
   sessions:
+    server: # disable the server session
     client:
       - name: default
+        config: remote-cache-config.xml
+#  spring:
+#    session:
+#      use-entry-processor: false
+coherence.tcmp.enabled: false

--- a/samples/spring-session-demo/spring-session-demo-app/src/main/resources/remote-cache-config.xml
+++ b/samples/spring-session-demo/spring-session-demo-app/src/main/resources/remote-cache-config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright (c) 2023, Oracle and/or its affiliates.
+  Licensed under the Universal Permissive License v 1.0 as shown at
+  https://oss.oracle.com/licenses/upl.
+-->
+
+<cache-config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xmlns="http://xmlns.oracle.com/coherence/coherence-cache-config"
+              xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-cache-config coherence-cache-config.xsd">
+
+    <caching-scheme-mapping>
+        <cache-mapping>
+            <cache-name>*</cache-name>
+            <scheme-name>remote</scheme-name>
+        </cache-mapping>
+    </caching-scheme-mapping>
+
+    <caching-schemes>
+        <remote-cache-scheme>
+            <scheme-name>remote</scheme-name>
+            <service-name>ExtendTcpCacheService</service-name>
+            <initiator-config>
+                <outgoing-message-handler>
+                    <request-timeout>5s</request-timeout>
+                </outgoing-message-handler>
+            </initiator-config>
+        </remote-cache-scheme>
+    </caching-schemes>
+</cache-config>


### PR DESCRIPTION
- Add Spring Boot property `coherence.spring.session.use-entry-processor`
- Add property `useEntryProcessor` to `EnableCoherenceHttpSession` annotation`
- Add documentation
- Add tests

resolves #167 