### PR TITLE
gh-257 Upgrade to Spring Boot 3.2.0 + Spring Framework 6.1.1

### DIFF
--- a/coherence-spring-boot-starter/src/test/java/com/oracle/coherence/spring/boot/tests/CoherenceSpringSessionAutoConfigurationTests.java
+++ b/coherence-spring-boot-starter/src/test/java/com/oracle/coherence/spring/boot/tests/CoherenceSpringSessionAutoConfigurationTests.java
@@ -7,7 +7,6 @@
 package com.oracle.coherence.spring.boot.tests;
 
 import com.oracle.coherence.spring.boot.autoconfigure.CoherenceAutoConfiguration;
-import com.oracle.coherence.spring.boot.autoconfigure.CoherenceProperties;
 import com.oracle.coherence.spring.boot.autoconfigure.session.CoherenceSpringSessionAutoConfiguration;
 import com.oracle.coherence.spring.session.CoherenceIndexedSessionRepository;
 import org.junit.jupiter.api.Test;
@@ -30,7 +29,6 @@ public class CoherenceSpringSessionAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(CoherenceAutoConfiguration.class))
-			.withConfiguration(AutoConfigurations.of(CoherenceProperties.class))
 			.withConfiguration(AutoConfigurations.of(SessionProperties.class))
 			.withConfiguration(AutoConfigurations.of(ServerProperties.class))
 			.withConfiguration(AutoConfigurations.of(CoherenceSpringSessionAutoConfiguration.class))

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/messaging/CoherencePublisherRegistrar.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/messaging/CoherencePublisherRegistrar.java
@@ -15,7 +15,7 @@
  */
 
 /*
- * Copyright (c) 2021 Oracle and/or its affiliates.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates.
  */
 package com.oracle.coherence.spring.messaging;
 
@@ -42,6 +42,8 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Andy Wilksinson
+ * @author Vaso Putica
+ * @author Gunnar Hillert
  *
  * @since 3.0
  */
@@ -82,7 +84,13 @@ public class CoherencePublisherRegistrar implements ImportBeanDefinitionRegistra
 		beanDefinitionBuilder.addPropertyValue("maxBlock", attributes.get("maxBlock"));
 
 		AbstractBeanDefinition beanDefinition = beanDefinitionBuilder.getBeanDefinition();
-		beanDefinition.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, serviceInterface);
+		try {
+			beanDefinition.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, Class.forName(serviceInterface));
+		}
+		catch (ClassNotFoundException ex) {
+			throw new IllegalStateException(String.format("Unable to get the class for the provided serviceInterface name '%s'.",
+					serviceInterface), ex);
+		}
 
 		String id = (String) attributes.get("name");
 		if (!StringUtils.hasText(id)) {

--- a/coherence-spring-session/src/main/java/com/oracle/coherence/spring/session/CoherenceIndexedSessionRepository.java
+++ b/coherence-spring-session/src/main/java/com/oracle/coherence/spring/session/CoherenceIndexedSessionRepository.java
@@ -35,7 +35,9 @@ import org.springframework.session.MapSession;
 import org.springframework.session.PrincipalNameIndexResolver;
 import org.springframework.session.SaveMode;
 import org.springframework.session.Session;
+import org.springframework.session.SessionIdGenerator;
 import org.springframework.session.SessionRepository;
+import org.springframework.session.UuidSessionIdGenerator;
 import org.springframework.session.events.AbstractSessionEvent;
 import org.springframework.util.Assert;
 
@@ -87,6 +89,8 @@ public class CoherenceIndexedSessionRepository implements FindByIndexNameSession
 	 * Shall a Coherence Entry Processor be used for handling updates to session? Defaults to true.
 	 */
 	private boolean useEntryProcessor = true;
+
+	private SessionIdGenerator sessionIdGenerator = UuidSessionIdGenerator.getInstance();
 
 	/**
 	 * Create a new {@link CoherenceIndexedSessionRepository} instance.
@@ -255,6 +259,7 @@ public class CoherenceIndexedSessionRepository implements FindByIndexNameSession
 			deleteById(saved.getId());
 			return null;
 		}
+		saved.setSessionIdGenerator(this.sessionIdGenerator);
 		return new CoherenceSpringSession(this, saved, false);
 	}
 
@@ -273,7 +278,9 @@ public class CoherenceIndexedSessionRepository implements FindByIndexNameSession
 
 		final Map<String, CoherenceSpringSession> sessionMap = new HashMap<>(sessions.size());
 		for (Map.Entry<String, MapSession> session : sessions) {
-			sessionMap.put(session.getValue().getId(), new CoherenceSpringSession(this, session.getValue(), false));
+			final MapSession mapSession = session.getValue();
+			mapSession.setSessionIdGenerator(this.sessionIdGenerator);
+			sessionMap.put(session.getValue().getId(), new CoherenceSpringSession(this, mapSession, false));
 		}
 		return sessionMap;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -166,17 +166,17 @@
 		<log4j.version>2.21.1</log4j.version>
 		<mockito.version>5.7.0</mockito.version>
 		<modelmapper.version>3.1.1</modelmapper.version>
-		<org.springframework.version>6.0.13</org.springframework.version>
-		<org.springframework.data.version>2023.0.3</org.springframework.data.version>
+		<org.springframework.version>6.1.1</org.springframework.version>
+		<org.springframework.data.version>2023.1.0</org.springframework.data.version>
 		<reactor.version>3.5.9</reactor.version>
 		<resilience4j.version>2.1.0</resilience4j.version>
 		<slf4j-api.version>2.0.9</slf4j-api.version>
-		<spring-boot.version>3.1.5</spring-boot.version>
-		<spring-cloud.version>2022.0.4</spring-cloud.version>
-		<spring-data-bom.version>2023.0.3</spring-data-bom.version>
-		<spring-session.version>3.1.2</spring-session.version>
+		<spring-boot.version>3.2.0</spring-boot.version>
+		<spring-cloud.version>2023.0.0-RC1</spring-cloud.version>
+		<spring-data-bom.version>2023.1.0</spring-data-bom.version>
+		<spring-session.version>3.2.0</spring-session.version>
 		<spring-security.version>6.1.5</spring-security.version>
-		<tomcat.version>10.1.15</tomcat.version>
+		<tomcat.version>10.1.16</tomcat.version>
 	</properties>
 
 	<distributionManagement>


### PR DESCRIPTION
- Set FactoryBean.OBJECT_TYPE_ATTRIBUTE as a class, not as a String value
- Make CoherenceIndexedSessionRepository use the (default) UuidSessionIdGenerator
- Upgrade Spring Session dependency to 3.2.0
- Upgrade Spring Data BOM to 2023.1.0
- Upgrade Spring Cloud to 2023.0.0-RC1
- Upgrade Tomcat to 10.1.16