### PR TITLE
gh-296 Coherence Spring Core - use spring-jcl only

### DIFF
--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/ExtractorService.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/ExtractorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -19,8 +19,8 @@ import com.oracle.coherence.spring.configuration.support.CoherenceAnnotationUtil
 import com.oracle.coherence.spring.configuration.support.CommonExtractorFactories;
 import com.tangosol.util.Extractors;
 import com.tangosol.util.ValueExtractor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.InjectionPoint;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -34,7 +34,7 @@ import org.springframework.util.Assert;
  */
 public class ExtractorService {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(ExtractorService.class);
+	private static final Log logger = LogFactory.getLog(ExtractorService.class);
 
 	private final ConfigurableApplicationContext applicationContext;
 
@@ -50,7 +50,10 @@ public class ExtractorService {
 
 		final Class extractorFactoryClass = ExtractorFactory.class;
 		final String[] beanNames = this.applicationContext.getBeanNamesForType(ExtractorFactory.class);
-		LOGGER.debug("Found {} beans in the application context for bean type {}", beanNames.length, extractorFactoryClass.getName());
+
+		if (logger.isDebugEnabled()) {
+			logger.debug(String.format("Found %s beans in the application context for bean type s%", beanNames.length, extractorFactoryClass.getName()));
+		}
 
 		final Collection<ExtractorFactory> beans = CoherenceAnnotationUtils.getBeansOfTypeWithAnnotation(
 				this.applicationContext,

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/FilterService.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/FilterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -19,8 +19,8 @@ import com.oracle.coherence.spring.configuration.support.CoherenceAnnotationUtil
 import com.oracle.coherence.spring.configuration.support.CommonFilterFactories;
 import com.tangosol.util.Filter;
 import com.tangosol.util.Filters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.InjectionPoint;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -34,7 +34,7 @@ import org.springframework.util.Assert;
  */
 public class FilterService {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(FilterService.class);
+	private static final Log logger = LogFactory.getLog(FilterService.class);
 
 	private final ConfigurableApplicationContext applicationContext;
 
@@ -50,7 +50,10 @@ public class FilterService {
 
 		final Class filterFactoryClass = FilterFactory.class;
 		final String[] beanNames = this.applicationContext.getBeanNamesForType(filterFactoryClass);
-		LOGGER.debug("Found {} beans in the application context for bean type {}", beanNames.length, filterFactoryClass.getName());
+
+		if (logger.isDebugEnabled()) {
+			logger.debug(String.format("Found %s beans in the application context for bean type %s", beanNames.length, filterFactoryClass.getName()));
+		}
 
 		final Collection<FilterFactory> beans = CoherenceAnnotationUtils.getBeansOfTypeWithAnnotation(
 				this.applicationContext,

--- a/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/support/CoherenceAnnotationUtils.java
+++ b/coherence-spring-core/src/main/java/com/oracle/coherence/spring/configuration/support/CoherenceAnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates.
  *
  * Licensed under the Universal Permissive License v 1.0 as shown at
  * https://oss.oracle.com/licenses/upl.
@@ -12,8 +12,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.InjectionPoint;
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
  */
 public final class CoherenceAnnotationUtils {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CoherenceAnnotationUtils.class);
+	private static final Log logger = LogFactory.getLog(CoherenceAnnotationUtils.class);
 
 	private CoherenceAnnotationUtils() {
 		throw new AssertionError("Utility Class.");
@@ -103,7 +103,10 @@ public final class CoherenceAnnotationUtils {
 		final List<T> foundSpringBeans = new ArrayList<>();
 
 		final String[] beanNames = applicationContext.getBeanNamesForType(beanType);
-		LOGGER.debug("Found {} beans in the application context for bean type {}", beanNames.length, beanType.getName());
+
+		if (logger.isDebugEnabled()) {
+			logger.debug(String.format("Found %s beans in the application context for bean type %s", beanNames.length, beanType.getName()));
+		}
 
 		final ConfigurableListableBeanFactory beanFactory = applicationContext.getBeanFactory();
 
@@ -120,11 +123,15 @@ public final class CoherenceAnnotationUtils {
 					boolean foundAnnotation = beanMethodMetadata.getAnnotations().isPresent(annotationType);
 
 					if (foundAnnotation) {
-						LOGGER.debug("Found annotation {} on Bean {}.", annotationType.getName(), beanName);
+						if (logger.isDebugEnabled()) {
+							logger.debug(String.format("Found annotation %s on Bean %s.", annotationType.getName(), beanName));
+						}
 						foundSpringBeans.add(applicationContext.getBean(beanName, beanType));
 					}
 					else {
-						LOGGER.debug("The annotation {} was not found on Bean {}.", annotationType.getName(), beanName);
+						if (logger.isDebugEnabled()) {
+							logger.debug(String.format("The annotation %s was not found on Bean %s.", annotationType.getName(), beanName));
+						}
 					}
 				}
 
@@ -132,15 +139,21 @@ public final class CoherenceAnnotationUtils {
 				boolean foundAnnotation = classLevelAnnotationMetadata.getAnnotations().isPresent(annotationType);
 
 				if (foundAnnotation) {
-					LOGGER.debug("Found class-level annotation {} on Bean {}.", annotationType.getName(), beanName);
+					if (logger.isDebugEnabled()) {
+						logger.debug(String.format("Found class-level annotation %s on Bean %s.", annotationType.getName(), beanName));
+					}
 					foundSpringBeans.add(applicationContext.getBean(beanName, beanType));
 				}
 				else {
-					LOGGER.debug("The annotation {} was not found on Bean {}.", annotationType.getName(), beanName);
+					if (logger.isDebugEnabled()) {
+						logger.debug(String.format("The annotation %s was not found on Bean %s.", annotationType.getName(), beanName));
+					}
 				}
 			}
 			else {
-				LOGGER.debug("Ignoring beanDefinition {} as it is not an AnnotatedBeanDefinition.", beanName);
+				if (logger.isDebugEnabled()) {
+					logger.debug("Ignoring beanDefinition " + beanName + " as it is not an AnnotatedBeanDefinition.");
+				}
 			}
 		}
 		return foundSpringBeans;


### PR DESCRIPTION
- Ensure that the core Spring Framework only modules use Commons Logging (provided by spring-jcl), only
- Remove SLF4J code from non-test classes
- Add checks for whether the logging level is enabled before doing the actual log statements

resolves #296 296