### PR TITLE
gh-358 Spring Session: Allow for updating existing HTTP Sessions with a new session timeout value

### DIFF
--- a/coherence-spring-session/src/main/java/com/oracle/coherence/spring/session/CoherenceIndexedSessionRepository.java
+++ b/coherence-spring-session/src/main/java/com/oracle/coherence/spring/session/CoherenceIndexedSessionRepository.java
@@ -14,8 +14,10 @@ import java.util.Set;
 
 import com.oracle.coherence.spring.session.events.CoherenceSessionEventMapListener;
 import com.oracle.coherence.spring.session.support.PrincipalNameExtractor;
+import com.tangosol.coherence.memcached.server.MemcachedHelper;
 import com.tangosol.net.NamedCache;
 import com.tangosol.net.cache.CacheMap;
+import com.tangosol.util.BinaryEntry;
 import com.tangosol.util.Filter;
 import com.tangosol.util.filter.EqualsFilter;
 import jakarta.annotation.PostConstruct;
@@ -300,4 +302,32 @@ public class CoherenceIndexedSessionRepository implements FindByIndexNameSession
 		this.eventPublisher = applicationEventPublisher;
 	}
 
+	/**
+	 * Clear all sessions.
+	 */
+	public void clearAllSessions() {
+		this.sessionCache.truncate();
+	}
+
+	/**
+	 * Reset the max inactive interval for all active sessions.
+	 */
+	public void resetMaxInactiveIntervalForActiveSessions() {
+		final long expirationInMillis = this.defaultMaxInactiveInterval.toMillis();
+		this.sessionCache.invokeAll((entry) -> {
+
+			final MapSession mapSession = entry.getValue();
+
+			if (entry.getValue().isExpired()) {
+				return null;
+			}
+
+			mapSession.setMaxInactiveInterval(Duration.ofMillis(expirationInMillis));
+			final BinaryEntry binaryEntry = MemcachedHelper.getBinaryEntry(entry);
+			binaryEntry.expire(expirationInMillis);
+
+			entry.setValue(mapSession);
+			return null;
+		});
+	}
 }


### PR DESCRIPTION
- add method `resetMaxInactiveIntervalForActiveSessions` to `CoherenceIndexedSessionRepository`
- add method `clearAllSessions` to `CoherenceIndexedSessionRepository`
- add tests

resolves #358 