### PR TITLE
Force Spring Boot's gson version.

### DIFF
--- a/coherence-spring-boot-starter/pom.xml
+++ b/coherence-spring-boot-starter/pom.xml
@@ -67,6 +67,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>${gson.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.oracle.coherence.spring</groupId>
 			<artifactId>coherence-spring-tests</artifactId>
 			<version>${project.version}</version>

--- a/coherence-spring-core/pom.xml
+++ b/coherence-spring-core/pom.xml
@@ -47,6 +47,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>${gson.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 		</dependency>

--- a/coherence-spring-data/pom.xml
+++ b/coherence-spring-data/pom.xml
@@ -52,6 +52,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>${gson.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 		</dependency>

--- a/coherence-spring-session/pom.xml
+++ b/coherence-spring-session/pom.xml
@@ -48,6 +48,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>${gson.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.oracle.coherence.spring</groupId>
 			<artifactId>coherence-spring-core</artifactId>
 			<version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,10 @@
 		<bcprov.version>1.79</bcprov.version>
 		<bedrock.version>7.0.2</bedrock.version>
 		<coherence.groupId>com.oracle.coherence.ce</coherence.groupId>
-		<coherence.version>24.09</coherence.version>
+		<coherence.version>24.09.1-SNAPSHOT</coherence.version>
 		<coherence-hibernate.version>3.0.2</coherence-hibernate.version>
 		<classgraph.version>4.8.168</classgraph.version>
+		<gson.version>2.11.0</gson.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<hibernate.version>6.6.0.Final</hibernate.version>
 		<hsqldb.version>2.7.2</hsqldb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 		<bcprov.version>1.79</bcprov.version>
 		<bedrock.version>7.0.2</bedrock.version>
 		<coherence.groupId>com.oracle.coherence.ce</coherence.groupId>
-		<coherence.version>24.09.1-SNAPSHOT</coherence.version>
+		<coherence.version>24.09</coherence.version>
 		<coherence-hibernate.version>3.0.2</coherence-hibernate.version>
 		<classgraph.version>4.8.168</classgraph.version>
 		<gson.version>2.11.0</gson.version>


### PR DESCRIPTION
Coherence 24.09.1-SNAPSHOT rolled back to an older version of grpc which in turn rolled gson back to an older version that isn't compatible with Spring Boot.